### PR TITLE
feat: update .chezmoiignore to ignore documentation and development files

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -4,15 +4,9 @@
 # 必要に応じてこのファイルに追記してください。
 
 # Documentation files - ドキュメントファイル
-README.md
-Readme.md
-readme.md
-MIGRATION.md
-CHANGELOG.md
 *.md
 
 # Development and maintenance files - 開発・メンテナンス用ファイル
-CLAUDE.md
 .gitignore
 .github/
 

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,2 +1,33 @@
+# Chezmoi ignore file
+# このファイルは、chezmoiがホームディレクトリに適用しないファイルやディレクトリを指定します。
+# 新しいドキュメントファイルや一時ファイルを作成した場合は、
+# 必要に応じてこのファイルに追記してください。
+
+# Documentation files - ドキュメントファイル
+README.md
 Readme.md
+readme.md
+MIGRATION.md
+CHANGELOG.md
+*.md
+
+# Development and maintenance files - 開発・メンテナンス用ファイル
+CLAUDE.md
+.gitignore
+.github/
+
+# Backup files - バックアップファイル
 bakups/
+*.bak
+*.backup
+*~
+
+# Temporary files - 一時ファイル
+*.tmp
+*.temp
+
+# IDE and editor files - IDE・エディタファイル
+.vscode/
+.idea/
+*.swp
+*.swo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,11 @@ Ubuntu環境向けのChezmoiで管理された個人用dotfilesリポジトリ�
 - `chezmoi diff` - ソースとターゲット状態の差分を表示
 - `chezmoi cd` - chezmoiソースディレクトリに移動
 
+### ファイル管理とIgnore設定
+
+- `.chezmoiignore` - ホームディレクトリに適用しないファイルを指定
+- 新しいドキュメントファイルや開発用ファイルを追加した場合は、必要に応じて`.chezmoiignore`に追記
+
 ### リントと品質チェック
 
 - `shfmt -i 2 -ci -w .` - シェルスクリプトを2スペースインデントでフォーマット


### PR DESCRIPTION
Add comprehensive markdown file patterns and development file ignores to .chezmoiignore

- Add comprehensive markdown file patterns (*.md, README.md, etc.)
- Include development files (.github/, CLAUDE.md, .gitignore)
- Add backup, temporary, and IDE file patterns
- Add Japanese documentation explaining when to update the ignore file
- Organize patterns into logical sections with clear categorization

Fixes #62

Generated with [Claude Code](https://claude.ai/code)