### PR TITLE
🐛 Fix logical operator error in fixedSizePNG.sh

### DIFF
--- a/dot_scripts/executable_fixedSizePNG.sh
+++ b/dot_scripts/executable_fixedSizePNG.sh
@@ -3,14 +3,14 @@
 # thanks to https://hostingstock.net/blog/20160206/
 
 check() {
-	if ! convert --version >/dev/null; then
-		echo "Need to install Imagemagick"
-		exit 1
-	fi
-	if ! exiftool >/dev/null; then
-		echo "Need to install exiftool"
-		exit 1
-	fi
+  if ! convert --version >/dev/null; then
+    echo "Need to install Imagemagick"
+    exit 1
+  fi
+  if ! exiftool >/dev/null; then
+    echo "Need to install exiftool"
+    exit 1
+  fi
 }
 get_random_text() {
 	text=$(LC_CTYPE=C tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w "$1" | head -n 1)

--- a/dot_scripts/executable_fixedSizePNG.sh
+++ b/dot_scripts/executable_fixedSizePNG.sh
@@ -13,8 +13,8 @@ check() {
   fi
 }
 get_random_text() {
-	text=$(LC_CTYPE=C tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w "$1" | head -n 1)
-	echo "$text"
+  text=$(LC_CTYPE=C tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w "$1" | head -n 1)
+  echo "$text"
 }
 
 check
@@ -37,9 +37,9 @@ img_file_size=$(wc -c <"$img_name")
 extra_text_size=$((target_size - 21 - img_file_size))
 
 if [ ${extra_text_size} -lt 1 ]; then
-	echo too small target size
-	rm "$img_name"
-	exit 1
+  echo too small target size
+  rm "$img_name"
+  exit 1
 fi
 
 extra_text_fn=$(mktemp)

--- a/dot_scripts/executable_fixedSizePNG.sh
+++ b/dot_scripts/executable_fixedSizePNG.sh
@@ -3,8 +3,14 @@
 # thanks to https://hostingstock.net/blog/20160206/
 
 check() {
-	convert --version >/dev/null || echo "Need to install Imagemagick" && exit 1
-	exiftool >/dev/null || echo "Need to install exiftool" && exit 1
+	if ! convert --version >/dev/null; then
+		echo "Need to install Imagemagick"
+		exit 1
+	fi
+	if ! exiftool >/dev/null; then
+		echo "Need to install exiftool"
+		exit 1
+	fi
 }
 get_random_text() {
 	text=$(LC_CTYPE=C tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w "$1" | head -n 1)


### PR DESCRIPTION
Fix logical operator precedence issue in fixedSizePNG.sh that caused script to exit even when dependencies were available.

Fixes #64

Generated with [Claude Code](https://claude.ai/code)