### PR TITLE
🐛 Improve error handling for cd commands in setup script

### DIFF
--- a/executable_once_setup_ubuntu.sh.tmpl
+++ b/executable_once_setup_ubuntu.sh.tmpl
@@ -78,8 +78,13 @@ curl -sSf https://rye.astral.sh/get | bash
 
 # Bitwarden SSH Agent
 git clone https://github.com/joaojacome/bitwarden-ssh-agent.git ~/.bw-ssh-agent
-cd ~/.bw-ssh-agent
-git checkout 6237a3604d640533ad4123d23e23ddfd4e3666d2 2>&1 > /dev/null
-cd $HOME
+if ! cd ~/.bw-ssh-agent; then
+  echo "Warning: Failed to change directory to ~/.bw-ssh-agent" >&2
+else
+  git checkout 6237a3604d640533ad4123d23e23ddfd4e3666d2 2>&1 > /dev/null
+fi
+if ! cd "$HOME"; then
+  echo "Warning: Failed to change directory to $HOME" >&2
+fi
 
 {{ end }}


### PR DESCRIPTION
Add proper error checking and logging for directory changes in the Bitwarden SSH Agent setup section:
- Check cd return values and log warnings to stderr on failure
- Continue execution rather than exit for optional components
- Use quoted $HOME variable for better path handling
- Only run git checkout if directory change succeeds

Fixes #65

Generated with [Claude Code](https://claude.ai/code)