### PR TITLE
add keybindings

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -71,3 +71,9 @@ if command -v mcfly >/dev/null 2>&1 && [[ -z "$MCFLY_LOADED" ]]; then
   export MCFLY_RESULTS=20
   export MCFLY_LOADED=1
 fi
+
+# keybindings
+if uname -a | grep microsoft >/dev/null 2>&1; then
+  bindkey '^[[1;5D' backward-word
+  bindkey '^[[1;5C' forward-word
+fi


### PR DESCRIPTION
タスク進行状況
 変更されたファイルの内容を確認
 キーバインドの機能を分析
 追加されたキーバインドの説明を作成
 PRの説明を更新
追加されたキーバインドの説明
このPRでは、WSL2（Windows Subsystem for Linux）環境でのzshにおいて、Ctrl+矢印キーによる単語単位の移動を可能にするキーバインドが追加されました。

変更内容
dot_zshrc:76-79 に以下のコードが追加されました：

# keybindings
if uname -a | grep microsoft >/dev/null 2>&1; then
  bindkey '^[[1;5D' backward-word
  bindkey '^[[1;5C' forward-word
fi
機能詳細
環境検出: uname -a | grep microsoft でMicrosoft/WSL環境かどうかを判定
キーバインド設定:
Ctrl+← ('^[[1;5D'): カーソルを前の単語の先頭に移動 (backward-word)
Ctrl+→ ('^[[1;5C'): カーソルを次の単語の先頭に移動 (forward-word)
メリット
効率的な編集: 長いコマンドラインで単語単位でのカーソル移動が可能
WSL固有の対応: WSL環境でのキーコード問題に対応
条件付き適用: WSL環境でのみ有効化され、他の環境に影響しない
対応するキーコード
^[[1;5D: Ctrl+Left Arrow（WSL環境での標準的なキーコード）
^[[1;5C: Ctrl+Right Arrow（WSL環境での標準的なキーコード）
これにより、WSL2でzshを使用する際のコマンドライン編集体験が大幅に向上します。