### PR TITLE
feat: add fzds command for simple Docker container selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,7 @@ GitHub Actionsが自動実行:
 ### 主要なfzfコマンド
 
 - `fzdc` - Dockerコンテナ選択・操作
+- `fzds` - Dockerコンテナ選択（名前のみ出力）
 - `fzgb` - Git ブランチ選択・チェックアウト
 - `fzgl` - Git ログ閲覧
 - `fzff` - ファイル検索・編集

--- a/FZF_UTILS.md
+++ b/FZF_UTILS.md
@@ -26,6 +26,37 @@ fzdc
   - `Ctrl-S`: コンテナ開始
   - `Ctrl-K`: コンテナ停止
 
+### 1.1. Docker Container Simple Selector (`fzds`)
+
+Dockerコンテナを選択し、コンテナ名のみを出力します。
+
+```bash
+fzds
+```
+
+**機能:**
+
+- 全コンテナの一覧表示
+- リッチなプレビュー（ステータス、IP、ポート、環境変数など）
+- 選択したコンテナ名を標準出力に出力
+- 他のDockerコマンドと組み合わせて使用可能
+
+**使用例:**
+
+```bash
+# ログを表示
+docker logs $(fzds)
+
+# コンテナを停止
+docker stop $(fzds)
+
+# コンテナを再起動
+docker restart $(fzds)
+
+# コンテナの詳細情報を表示
+docker inspect $(fzds)
+```
+
 ### 2. Git Branch Selector (`fzgb`)
 
 Gitブランチを選択してチェックアウトします。

--- a/dot_config/sh-like-aliases
+++ b/dot_config/sh-like-aliases
@@ -83,6 +83,7 @@ alias claude="npx @anthropic-ai/claude-code"
 
 # fzf便利ユーティリティ
 alias fzdc="$HOME/.scripts/fzf_utils.sh docker-container"
+alias fzds="$HOME/.scripts/fzf_utils.sh docker-container-select"
 alias fzgb="$HOME/.scripts/fzf_utils.sh git-branch"
 alias fzgl="$HOME/.scripts/fzf_utils.sh git-log"
 alias fzff="$HOME/.scripts/fzf_utils.sh file-search"


### PR DESCRIPTION
Added new fzds (fzf docker select) command that outputs only the selected container name for use with other Docker operations.

Closes #79

Generated with [Claude Code](https://claude.ai/code)