### PR TITLE
feat: add pre-commit hooks for automatic document formatting

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -9,6 +9,8 @@
 # Development and maintenance files - 開発・メンテナンス用ファイル
 .gitignore
 .github/
+.pre-commit-config.yaml
+.secrets.baseline
 
 # Backup files - バックアップファイル
 bakups/

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install uv and uvx
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@beta

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+---
+# Pre-commit configuration for dotfiles repository
+# Install: pip install pre-commit && pre-commit install
+# Run manually: pre-commit run --all-files
+
+repos:
+  # Shell script formatting and linting
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.8.0-1
+    hooks:
+      - id: shfmt
+        args: [-i, '2', -ci, -w]
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+
+  # Markdown linting
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.41.0
+    hooks:
+      - id: markdownlint
+        args: [--fix]
+
+  # Security scanning
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+
+  # General formatting and checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-added-large-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 # Pre-commit configuration for dotfiles repository
-# Install: pip install pre-commit && pre-commit install
-# Run manually: pre-commit run --all-files
+# Install: uvx pre-commit install
+# Run manually: uvx pre-commit run --all-files
 
 repos:
   # Shell script formatting and linting

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,112 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2025-06-09T09:34:42Z"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,32 @@ Ubuntu環境向けのChezmoiで管理された個人用dotfilesリポジトリ�
 - `shellcheck $(shfmt -f .)` - シェルスクリプトの問題をチェック
 - `markdownlint-cli2 .` - Markdownファイルをリント
 
+### Pre-commitフック
+
+コミット時の自動フォーマット・リントを有効にするには:
+
+```bash
+# pre-commitのインストール
+pip install pre-commit
+
+# フックの有効化（リポジトリ初期化時に実行）
+pre-commit install
+
+# 手動実行（全ファイル対象）
+pre-commit run --all-files
+```
+
+設定済みのフック:
+
+- **shfmt**: シェルスクリプトの自動フォーマット（2スペースインデント）
+- **shellcheck**: シェルスクリプトの静的解析
+- **markdownlint**: Markdownファイルの自動修正
+- **detect-secrets**: 機密情報の検出
+- **trailing-whitespace**: 行末空白の除去
+- **end-of-file-fixer**: ファイル末尾改行の統一
+- **check-yaml**: YAML構文チェック
+- **check-merge-conflict**: マージコンフリクトマーカーの検出
+
 ### Git操作
 
 dot_gitconfigで定義された豊富なGitエイリアスを含む:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,14 +31,11 @@ Ubuntu環境向けのChezmoiで管理された個人用dotfilesリポジトリ�
 コミット時の自動フォーマット・リントを有効にするには:
 
 ```bash
-# pre-commitのインストール
-pip install pre-commit
-
 # フックの有効化（リポジトリ初期化時に実行）
-pre-commit install
+uvx pre-commit install
 
 # 手動実行（全ファイル対象）
-pre-commit run --all-files
+uvx pre-commit run --all-files
 ```
 
 設定済みのフック:


### PR DESCRIPTION
Add pre-commit configuration for automatic document formatting on commit.

- Add .pre-commit-config.yaml with hooks matching existing CI workflow
- Add setup instructions to CLAUDE.md
- Update .chezmoiignore to exclude pre-commit files

Resolves #80

Generated with [Claude Code](https://claude.ai/code)