### PR TITLE
improve tmux pane resizing with repeat keys and multiple size levels

### DIFF
--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -25,10 +25,11 @@
 #   s または -    - ペインを横分割
 #   h,j,k,l      - ペイン間を移動
 #   M-h,j,k,l    - プレフィックスなしでペイン間を移動
-#   H,J,K,L      - ペインをリサイズ
-#   M-j,k,h,l    - プレフィックスなしでペインをリサイズ
+#   H,J,K,L      - ペインを大きくリサイズ（10px）
+#   M-h,j,k,l    - ペインを中程度リサイズ（3px）
+#   C-h,j,k,l    - ペインを細かくリサイズ（1px）
 #   S-Left/Right - ウィンドウ間を移動
-#   C-h/l        - ウィンドウ間を移動
+#   C-Left/Right - ウィンドウ間を移動
 #   M-m          - ペインを最大化/復元
 #   y            - ペインの同期を切り替え
 #   S            - 新しいセッションを作成
@@ -84,22 +85,24 @@ bind-key s split-window -v -c "#{pane_current_path}"
 bind | split-window -h -c "#{pane_current_path}"
 bind - split-window -v -c "#{pane_current_path}"
 
-# ペインリサイズ
-bind-key J resize-pane -D 5
-bind-key K resize-pane -U 5
-bind-key H resize-pane -L 5
-bind-key L resize-pane -R 5
+# ペインリサイズ（連続操作対応）
+# 大きくリサイズ（10ピクセル単位）
+bind-key -r H resize-pane -L 10
+bind-key -r J resize-pane -D 10
+bind-key -r K resize-pane -U 10
+bind-key -r L resize-pane -R 10
 
-bind-key M-j resize-pane -D
-bind-key M-k resize-pane -U
-bind-key M-h resize-pane -L
-bind-key M-l resize-pane -R
+# 中程度リサイズ（3ピクセル単位）
+bind-key -r M-h resize-pane -L 3
+bind-key -r M-j resize-pane -D 3
+bind-key -r M-k resize-pane -U 3
+bind-key -r M-l resize-pane -R 3
 
-# より細かいペインリサイズ
-bind -r H resize-pane -L 2
-bind -r J resize-pane -D 2
-bind -r K resize-pane -U 2
-bind -r L resize-pane -R 2
+# 細かいリサイズ（1ピクセル単位）
+bind-key -r C-h resize-pane -L 1
+bind-key -r C-j resize-pane -D 1
+bind-key -r C-k resize-pane -U 1
+bind-key -r C-l resize-pane -R 1
 
 # Use Alt-vim keys without prefix key to switch panes
 bind -n M-h select-pane -L
@@ -112,8 +115,8 @@ bind -n S-Left  previous-window
 bind -n S-Right next-window
 
 # より良いウィンドウ選択
-bind -r C-h select-window -t :-
-bind -r C-l select-window -t :+
+bind -r C-Left select-window -t :-
+bind -r C-Right select-window -t :+
 
 # No delay for escape key press
 set -sg escape-time 0


### PR DESCRIPTION
## Summary
- Add repeat key support (-r flag) for seamless continuous resizing
- Implement 3-tier resize system for different adjustment needs
- Fix key binding conflicts with pane navigation

## Changes
- **Large resize** (H,J,K,L): 10px increments for major adjustments
- **Medium resize** (M-h,j,k,l): 3px increments for moderate adjustments  
- **Fine resize** (C-h,j,k,l): 1px increments for precise positioning
- Update window selection keys to avoid conflicts (C-h/l → C-Left/Right)
- Comprehensive documentation updates in config comments

## Test plan
- [ ] Test repeat key functionality works without re-pressing prefix
- [ ] Verify all 3 resize levels work as expected
- [ ] Confirm no conflicts with existing pane navigation
- [ ] Check window selection still works with new key bindings

🤖 Generated with [Claude Code](https://claude.ai/code)