### PR TITLE
feat: add comprehensive user-level gitignore with additional Claude Code settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ git config commit.gpgsign true
 git config user.signingkey "$(ssh-add -L | grep 'SOME_CONDITION')"
 ```
 
+### ユーザーレベルGitignore設定
+
+このdotfilesは `~/.config/git/ignore` にユーザーレベルのgitignoreファイルを設定します。
+このファイルは全てのGitリポジトリで自動的に適用され、以下のような開発環境固有のファイルを無視します：
+
+- **Claude Code**: ローカル設定ファイル、キャッシュ、ログ
+- **開発ツール**: Mise/RTX設定、IDE固有ファイル、エディタ一時ファイル
+- **OS固有ファイル**: macOS、Windows、Linux生成ファイル
+- **セキュリティ**: 環境変数ファイル、SSHキー、APIトークン
+- **ビルド・キャッシュ**: 各言語のビルド成果物、パッケージマネージャーキャッシュ
+- **コンテナ**: Docker Compose overrides、Vagrantファイル
+
+プロジェクト固有のファイルを無視する場合は、各プロジェクトの `.gitignore` ファイルを使用してください。
+
 ## 設定内容
 
 - パッケージ管理ツールを利用したセットアップ

--- a/dot_config/git/ignore
+++ b/dot_config/git/ignore
@@ -1,0 +1,282 @@
+# User-level Git ignore file
+# This file will be located at ~/.config/git/ignore after chezmoi apply
+
+# =================================
+# Claude Code Local Settings
+# =================================
+**/.claude/settings.local.json
+.claude/scripts.local/
+settings.local.json
+
+# =================================
+# Mise/RTX Tool Version Manager
+# =================================
+mise.toml
+.mise.toml
+.rtxrc
+.tool-versions
+
+# =================================
+# OS Generated Files
+# =================================
+
+# macOS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Icon?
+
+# Windows
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+*.tmp
+*.temp
+Desktop.ini
+$RECYCLE.BIN/
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Linux
+.directory
+.fuse_hidden*
+.Trash-*
+.nfs*
+
+# =================================
+# Development Tools Local Settings
+# =================================
+
+# VS Code
+.vscode/settings.json
+.vscode/launch.json
+.vscode/extensions.json
+.vscode/tasks.json
+.history/
+
+# JetBrains IDEs
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/usage.statistics.xml
+.idea/dictionaries
+.idea/shelf
+.idea/aws.xml
+.idea/contentModel.xml
+.idea/dataSources.ids
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+.idea/gradle.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+.idea/modules.xml
+.idea/inspectionProfiles/
+.idea/artifacts/
+
+# Vim/Neovim
+.netrwhist
+*~
+.*.sw[a-p]
+.s[a-v][a-z]
+Session.vim
+Sessionx.vim
+.viminfo
+.nvimlog
+
+# Emacs
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+.org-id-locations
+*_archive
+ltximg/**
+*.rel
+
+# =================================
+# Security Sensitive Files
+# =================================
+
+# SSH Keys
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+*.pem
+*.key
+*.crt
+*.csr
+*.p12
+*.pfx
+
+# Environment Variables
+.env
+.env.local
+.env.*.local
+.envrc
+
+# API Keys & Tokens
+.secrets
+.token
+.credentials
+*api_key*
+*secret*
+*password*
+auth.json
+.netrc
+
+# =================================
+# Build and Cache Directories
+# =================================
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.npm
+.yarn-integrity
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+.venv
+.env
+.venv/
+ENV/
+env/
+venv/
+
+# Ruby
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+.bundle/
+vendor/bundle
+.rspec
+.rvmrc
+
+# Go
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+go.work
+
+# Rust
+target/
+Cargo.lock
+
+# Java
+*.class
+*.log
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+hs_err_pid*
+
+# C/C++
+*.o
+*.so
+*.a
+*.exe
+*.out
+
+# =================================
+# Temporary Files and Logs
+# =================================
+
+# General temporary files
+*.tmp
+*.temp
+*.swp
+*.swo
+*~
+*.bak
+*.orig
+
+# Log files
+*.log
+logs/
+*.out
+
+# Cache files
+.cache/
+*.cache
+.parcel-cache/
+.next/
+.nuxt/
+.vuepress/dist
+
+# Database
+*.db
+*.sqlite
+*.sqlite3
+
+# =================================
+# Documentation and Media
+# =================================
+
+# Compiled documentation
+docs/_build/
+site/
+
+# Large media files (uncomment if needed)
+# *.mp4
+# *.avi
+# *.mov
+# *.wmv
+# *.flv
+# *.webm
+# *.mp3
+# *.wav
+# *.flac
+# *.aac
+# *.ogg
+# *.wma

--- a/dot_config/git/ignore
+++ b/dot_config/git/ignore
@@ -7,6 +7,8 @@
 **/.claude/settings.local.json
 .claude/scripts.local/
 settings.local.json
+.claude/cache/
+.claude/*.log
 
 # =================================
 # Mise/RTX Tool Version Manager
@@ -26,7 +28,6 @@ mise.toml
 ._*
 .Spotlight-V100
 .Trashes
-ehthumbs.db
 Icon?
 
 # Windows
@@ -93,7 +94,6 @@ Sessionx.vim
 .nvimlog
 
 # Emacs
-*~
 \#*\#
 /.emacs.desktop
 /.emacs.desktop.lock
@@ -172,7 +172,6 @@ wheels/
 .installed.cfg
 *.egg
 .venv
-.env
 .venv/
 ENV/
 env/
@@ -199,10 +198,8 @@ vendor/bundle
 *.exe
 *.exe~
 *.dll
-*.so
 *.dylib
 *.test
-*.out
 go.work
 
 # Rust
@@ -223,28 +220,23 @@ hs_err_pid*
 
 # C/C++
 *.o
-*.so
 *.a
 *.exe
-*.out
 
 # =================================
 # Temporary Files and Logs
 # =================================
 
 # General temporary files
-*.tmp
 *.temp
 *.swp
 *.swo
-*~
 *.bak
 *.orig
 
 # Log files
 *.log
 logs/
-*.out
 
 # Cache files
 .cache/
@@ -280,3 +272,106 @@ site/
 # *.aac
 # *.ogg
 # *.wma
+
+# =================================
+# Shell & Development Tools
+# =================================
+
+# Starship cache
+.starship/cache/
+
+# Shell history files that might leak into projects
+.bash_history
+.zsh_history
+.fish_history
+
+# fzf cache/history
+.fzf_history
+
+# =================================
+# Container & Development Environment
+# =================================
+
+# Docker Compose overrides
+docker-compose.override.yml
+.dockerignore.local
+
+# Vagrant
+.vagrant/
+Vagrantfile.local
+
+# Development containers
+.devcontainer/local/
+
+# =================================
+# Additional Package Managers
+# =================================
+
+# pip
+.pip_download_cache/
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Composer (PHP)
+composer.phar
+vendor/
+
+# Bundler (alternative Ruby path)
+.bundle/
+
+# =================================
+# Additional IDE & Editors
+# =================================
+
+# Sublime Text
+*.sublime-workspace
+*.sublime-project
+
+# Atom
+.atom/
+
+# Brackets
+.brackets.json
+
+# =================================
+# Profiling & Debugging
+# =================================
+
+# Core dumps
+core
+core.*
+
+# Profiling output
+*.prof
+callgrind.*
+
+# =================================
+# Cloud & Deployment
+# =================================
+
+# Terraform
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+
+# AWS
+.aws/config.local
+.aws/credentials.local
+
+# =================================
+# Shared Libraries (consolidated)
+# =================================
+
+# Shared object files
+*.so
+*.dll
+*.dylib
+
+# =================================
+# Output Files (consolidated)
+# =================================
+
+# Compiled output
+*.out
+*.exe


### PR DESCRIPTION
Added comprehensive user-level gitignore at `dot_config/git/ignore` including:

**Additional Claude Code patterns:**
- `.claude/scripts.local/` - Claude Code local scripts directory
- `settings.local.json` - Claude Code local settings file

**Comprehensive coverage:**
- Claude Code settings (all local patterns)
- Mise/RTX tool version manager configs
- OS-generated files (macOS, Windows, Linux)
- Development tool local settings (VS Code, JetBrains, Vim, etc.)
- Security-sensitive files (SSH keys, env files, API tokens)
- Build/cache directories and temporary files

Resolves #85

Generated with [Claude Code](https://claude.ai/code)