### PR TITLE
Add model/effort/fork config to user skills

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -4,7 +4,9 @@
 # 必要に応じてこのファイルに追記してください。
 
 # Documentation files - ドキュメントファイル
-**/*.md
+# ルート直下の .md のみ除外（dot_claude/ 配下の SKILL.md や
+# rules/*.md はホームへ展開する必要があるため除外しない）
+/*.md
 
 # Superpowers docs - 設計ドキュメント
 docs/

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -62,27 +62,16 @@ Use specialized tools instead of shell commands:
 
 ## AI Agent Development Policy
 
-Claude operates as a manager and orchestrator, not a direct implementer.
+Claude はマネージャー兼オーケストレーターとして動作し、直接実装しない。
+実装は subagent (Task tool) に委譲する。
 
-### Core Principles
+委譲時のモデル選定、スキル別の `context: fork` 判定、
+プラグイン skill 呼出時のモデル明示規約などの詳細は
+`~/.claude/rules/delegation.md` を参照する。
 
-- **Delegate implementation**: Never implement directly. Always delegate to
-  subagents (Task tool with appropriate agent types)
-- **Granular task breakdown**: Split tasks into the smallest verifiable units.
-  Each task should be independently testable or verifiable
-- **PDCA cycle**: Plan → Do → Check → Act for each task iteration
+## 詳細ガイドライン
 
-### Requirements Gathering
+用途別の詳細ルールは必要に応じて読み込む:
 
-- Use AskUserQuestion tool repeatedly until all ambiguities are resolved
-- Clarify feature scope, acceptance criteria, and edge cases before delegation
-- Do not proceed with assumptions; confirm with the user
-
-### Task Delegation Requirements
-
-When delegating tasks to subagents, always provide:
-
-- **Completion criteria**: Clear definition of "done"
-- **Verification checklist**: Specific items to verify task completion
-- **Abort conditions**: When to stop and escalate (errors, blockers, scope creep)
-- **Context and constraints**: Relevant background information and limitations
+- `~/.claude/rules/delegation.md` — AI エージェント運用方針、
+  モデル選定、skill の fork 判定基準

--- a/dot_claude/rules/delegation.md
+++ b/dot_claude/rules/delegation.md
@@ -1,0 +1,58 @@
+# AI Agent Development Policy
+
+Claude operates as a manager and orchestrator, not a direct implementer.
+
+## Core Principles
+
+- **Delegate implementation**: Never implement directly. Always delegate to
+  subagents (Task tool with appropriate agent types)
+- **Granular task breakdown**: Split tasks into the smallest verifiable units.
+  Each task should be independently testable or verifiable
+- **PDCA cycle**: Plan → Do → Check → Act for each task iteration
+
+## Requirements Gathering
+
+- Use AskUserQuestion tool repeatedly until all ambiguities are resolved
+- Clarify feature scope, acceptance criteria, and edge cases before delegation
+- Do not proceed with assumptions; confirm with the user
+
+## Task Delegation Requirements
+
+When delegating tasks to subagents, always provide:
+
+- **Completion criteria**: Clear definition of "done"
+- **Verification checklist**: Specific items to verify task completion
+- **Abort conditions**: When to stop and escalate
+  (errors, blockers, scope creep)
+- **Context and constraints**: Relevant background information and limitations
+
+## Model Selection for Delegation
+
+用途に応じた最小モデルを選び、コスト・速度・推論力をバランスする。
+
+### 自作スキル (編集可能)
+
+SKILL.md のフロントマターに `model` と `effort` を明示する:
+
+- オーケストレーション / スクリプト雛形生成 / 単純な要約: `model: sonnet`
+- 機械的検査・フォーマット・リンクチェック等: `model: haiku` + `effort: low`
+- 深い推論・盲点抽出・批判的レビュー: `model: opus` + `effort: high`、
+  または sonnet ベース + 要所で opus subagent をチェックポイント起動
+
+### Forked skill の判定基準
+
+`context: fork` が有効なのは「現在の会話履歴を必要としない単発タスク」のみ:
+
+- **fork する**: markdown-check のような機械的検査、コードベース調査、
+  成果物を1回の出力で返せるタスク
+- **fork しない**: handover(会話履歴を要約), grill-me(対話型),
+  dev-workflow(メイン orchestrator) のように会話文脈や双方向対話が必要なもの
+
+fork する場合は `agent:` も指定する(Read 専用なら `Explore`、
+Edit 等が必要なら `general-purpose`)。
+
+### 編集不能なプラグイン skill の呼出
+
+feature-dev, superpowers, document-skills, commit-commands 等の
+プラグイン提供 skill は SKILL.md を編集できないため、呼出側 (Task/Agent) で
+`model` パラメータを明示する。プラグイン側のデフォルトに任せない。

--- a/dot_claude/skills/dev-workflow/SKILL.md
+++ b/dot_claude/skills/dev-workflow/SKILL.md
@@ -14,6 +14,8 @@ description: |
   以下では使用しない:
   - 単純な質問や調査のみの場合
 allowed-tools: Read, Glob, Grep, Skill, Bash(git branch:*), Bash(git worktree list:*), Bash(git log:*), Bash(git diff:*), Bash(git status:*)
+model: sonnet
+effort: medium
 ---
 
 # Dev Workflow
@@ -31,6 +33,11 @@ allowed-tools: Read, Glob, Grep, Skill, Bash(git branch:*), Bash(git worktree li
 - `/grill-me`（カスタムスキル）
 - `/commit-commands:commit-push-pr`（commit-commands プラグイン）
 - `/handover`（カスタムスキル、任意）
+
+編集不能なプラグイン skill (superpowers, commit-commands 等) に委譲する
+際は、Task/Agent 呼出側でモデルを明示する (例: 機械的な実装実行は
+`model: sonnet`、深い設計判断は `model: opus`)。詳細は
+`~/.claude/rules/delegation.md` を参照。
 
 ## 環境検出
 

--- a/dot_claude/skills/grill-me/SKILL.md
+++ b/dot_claude/skills/grill-me/SKILL.md
@@ -5,6 +5,7 @@ description: |
   shared understanding, resolving each branch of the decision tree.
   Use when user wants to stress-test a plan, get grilled on their design,
   or mentions "grill me".
+allowed-tools: Read, Glob, Grep, Task
 model: sonnet
 effort: high
 ---

--- a/dot_claude/skills/grill-me/SKILL.md
+++ b/dot_claude/skills/grill-me/SKILL.md
@@ -5,6 +5,8 @@ description: |
   shared understanding, resolving each branch of the decision tree.
   Use when user wants to stress-test a plan, get grilled on their design,
   or mentions "grill me".
+model: sonnet
+effort: high
 ---
 
 <!-- Based on https://github.com/mattpocock/skills (MIT License, Copyright (c) 2026 Matt Pocock) -->
@@ -18,3 +20,13 @@ Ask the questions one at a time.
 
 If a question can be answered by exploring the codebase, explore the codebase
 instead.
+
+## Checkpoint evaluation
+
+This skill runs on Sonnet for fast iterative questioning. Before concluding
+a major decision branch, or if the dialogue starts going in circles, spawn
+an Opus subagent (Task tool with `model: opus`) to audit the conversation
+so far and surface blind spots, unstated assumptions, or contradictions the
+Sonnet loop may have missed. Feed the subagent a concise summary of the
+decisions made and open questions, and integrate its findings into the next
+round of questions.

--- a/dot_claude/skills/handover/SKILL.md
+++ b/dot_claude/skills/handover/SKILL.md
@@ -11,6 +11,8 @@ description: |
   - 「コンパクト前に保存」「文脈を残して」
   - 「次のセッションに引き継ぎたい」
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git branch:*), Bash(date:*)
+model: sonnet
+effort: medium
 ---
 
 # Session Handover

--- a/dot_claude/skills/markdown-check/SKILL.md
+++ b/dot_claude/skills/markdown-check/SKILL.md
@@ -14,6 +14,11 @@ description: |
   - 「dead links」「invalid links」「link checker」「doc review」
   - PR前のドキュメントチェック、ドキュメント更新後の確認
   - 「ドキュメントに問題ないか」「リンクが正しいか」
+allowed-tools: Read, Glob, Grep, Edit, Bash(git diff:*), WebFetch
+context: fork
+agent: general-purpose
+model: haiku
+effort: low
 ---
 
 # Markdown Documentation Integrity Check
@@ -150,6 +155,11 @@ Globツールで **/*.md を検索
 ```
 
 ## 自動修正
+
+このスキルは `context: fork` で隔離 subagent として動作する。
+fork 実行中は対話的確認ができないため、**検出と修正提案の生成まで**を
+行い、実際の Edit 適用は返却レポートを受けたメインセッションで
+ユーザー確認の上で実施する。
 
 ユーザー確認後に以下の修正を実行可能:
 

--- a/dot_claude/skills/uv-script/SKILL.md
+++ b/dot_claude/skills/uv-script/SKILL.md
@@ -2,6 +2,8 @@
 name: uv-script
 description: Create standalone Python scripts using uv shebang with PEP 723 inline metadata. Use when creating single-file Python tools or scripts that need dependency management without a full project setup.
 allowed-tools: Read, Write, Glob
+model: sonnet
+effort: low
 ---
 
 # uv Shebang Python Script


### PR DESCRIPTION
## Summary

- 自作 skill 5件 (handover / markdown-check / grill-me / dev-workflow / uv-script) の SKILL.md フロントマターに `model` / `effort` / `context: fork` / `agent` を明示
- AI Agent Development Policy を `dot_claude/rules/delegation.md` に切り出し、CLAUDE.md はポインタ化
- Model Selection for Delegation 規約を新設(fork 判定基準、プラグイン skill 呼出時のモデル明示)
- `.chezmoiignore` の `**/*.md` → `/*.md` に修正し、`dot_claude/` 配下の .md がホームへ展開されるよう修正

## 各 skill の設定

| skill | model | effort | fork |
| --- | --- | --- | --- |
| handover | sonnet | medium | ✗ (会話履歴要) |
| markdown-check | haiku | low | ✓ general-purpose |
| grill-me | sonnet | high | ✗ (対話型) + Opus checkpoint |
| dev-workflow | sonnet | medium | ✗ (orchestrator) |
| uv-script | sonnet | low | ✗ |

## Test plan

- [ ] `chezmoi apply` で `~/.claude/rules/delegation.md` が展開される
- [ ] `chezmoi apply` で各 SKILL.md の更新が反映される
- [ ] `chezmoi apply` でルート直下の README.md / CLAUDE.md などが誤って展開されない
- [ ] `/handover` `/markdown-check` `/grill-me` `/dev-workflow` `/uv-script` が期待モデルで起動する
- [ ] markdown-check が `context: fork` で隔離実行される

🤖 Generated with [Claude Code](https://claude.com/claude-code)