### PR TITLE
Add rtk integration for Claude Code token cost reduction

### DIFF
--- a/.github/workflows/rtk-update-check.yml
+++ b/.github/workflows/rtk-update-check.yml
@@ -1,0 +1,372 @@
+name: rtk update check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # 毎週月曜 09:00 UTC (JST 18:00)
+  workflow_dispatch:
+    inputs:
+      skip_cooldown:
+        description: 'Skip the 7-day cooldown period'
+        type: boolean
+        default: false
+      force_pr:
+        description: 'Force create PR even if already exists'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-update:
+    runs-on: ubuntu-latest
+    outputs:
+      has_update: ${{ steps.check.outputs.has_update }}
+      new_version: ${{ steps.check.outputs.new_version }}
+      new_tag: ${{ steps.check.outputs.new_tag }}
+      new_commit: ${{ steps.check.outputs.new_commit }}
+      published_at: ${{ steps.check.outputs.published_at }}
+      days_since_release: ${{ steps.check.outputs.days_since_release }}
+      cooldown_met: ${{ steps.check.outputs.cooldown_met }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for rtk updates
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SKIP_COOLDOWN: ${{ inputs.skip_cooldown || 'false' }}
+        run: |
+          CURRENT_VERSION=$(jq -r '.version' rtk/manifest.json)
+          echo "Current pinned version: $CURRENT_VERSION"
+
+          # Get latest release info
+          RELEASE_JSON=$(gh api repos/rtk-ai/rtk/releases/latest)
+          NEW_TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name')
+          NEW_VERSION=${NEW_TAG#v}
+          PUBLISHED_AT=$(echo "$RELEASE_JSON" | jq -r '.published_at')
+          COMMIT_SHA=$(echo "$RELEASE_JSON" | jq -r '.target_commitish')
+
+          # Calculate days since release
+          PUBLISHED_TS=$(date -d "$PUBLISHED_AT" +%s)
+          NOW_TS=$(date +%s)
+          DAYS_SINCE=$(( (NOW_TS - PUBLISHED_TS) / 86400 ))
+
+          echo "Latest version: $NEW_VERSION (tag: $NEW_TAG)"
+          echo "Published: $PUBLISHED_AT ($DAYS_SINCE days ago)"
+
+          # Check if update needed
+          if [ "$CURRENT_VERSION" = "$NEW_VERSION" ]; then
+            echo "Already up to date."
+            echo "has_update=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "has_update=true"
+            echo "new_version=$NEW_VERSION"
+            echo "new_tag=$NEW_TAG"
+            echo "new_commit=$COMMIT_SHA"
+            echo "published_at=$PUBLISHED_AT"
+            echo "days_since_release=$DAYS_SINCE"
+          } >> "$GITHUB_OUTPUT"
+
+          # Cooldown check (7 days)
+          if [ "$SKIP_COOLDOWN" = "true" ]; then
+            echo "Cooldown skipped (manual override)"
+            echo "cooldown_met=true" >> "$GITHUB_OUTPUT"
+          elif [ "$DAYS_SINCE" -ge 7 ]; then
+            echo "Cooldown period met (>= 7 days)"
+            echo "cooldown_met=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Cooldown NOT met ($DAYS_SINCE/7 days). Skipping update."
+            echo "cooldown_met=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  update-manifest:
+    needs: check-update
+    if: needs.check-update.outputs.has_update == 'true' && needs.check-update.outputs.cooldown_met == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      hook_changed: ${{ steps.update-hook.outputs.hook_changed }}
+      suspicious: ${{ steps.lint-hook.outputs.suspicious }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Download checksums and update manifest
+        id: update-manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ needs.check-update.outputs.new_version }}
+          NEW_TAG: ${{ needs.check-update.outputs.new_tag }}
+          NEW_COMMIT: ${{ needs.check-update.outputs.new_commit }}
+        run: |
+          # Download checksums.txt from release
+          CHECKSUMS=$(gh release download "$NEW_TAG" --repo rtk-ai/rtk --pattern checksums.txt --output -)
+
+          # Platform mapping: nix system -> rtk target -> extract sha256
+          declare -A TARGETS
+          TARGETS[x86_64-linux]=$(jq -r '.platforms["x86_64-linux"].target' rtk/manifest.json)
+          TARGETS[aarch64-linux]=$(jq -r '.platforms["aarch64-linux"].target' rtk/manifest.json)
+          TARGETS[x86_64-darwin]=$(jq -r '.platforms["x86_64-darwin"].target' rtk/manifest.json)
+          TARGETS[aarch64-darwin]=$(jq -r '.platforms["aarch64-darwin"].target' rtk/manifest.json)
+
+          for SYSTEM in x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin; do
+            TARGET=${TARGETS[$SYSTEM]}
+            TARBALL="rtk-${TARGET}.tar.gz"
+            SHA256=$(echo "$CHECKSUMS" | grep "$TARBALL" | awk '{print $1}')
+            if [ -z "$SHA256" ]; then
+              echo "ERROR: No checksum found for $TARBALL"
+              exit 1
+            fi
+            echo "  $SYSTEM ($TARGET): $SHA256"
+            # Update manifest.json using jq
+            jq --arg sys "$SYSTEM" --arg sha "$SHA256" \
+              '.platforms[$sys].sha256 = $sha' rtk/manifest.json > tmp.json && mv tmp.json rtk/manifest.json
+          done
+
+          # Update version, tag, commit
+          jq --arg ver "$NEW_VERSION" --arg tag "$NEW_TAG" --arg commit "$NEW_COMMIT" \
+            '.version = $ver | .tag = $tag | .commit = $commit' rtk/manifest.json > tmp.json && mv tmp.json rtk/manifest.json
+
+          echo "Updated manifest.json:"
+          cat rtk/manifest.json
+
+      - name: Update hook script
+        id: update-hook
+        env:
+          NEW_COMMIT: ${{ needs.check-update.outputs.new_commit }}
+          NEW_TAG: ${{ needs.check-update.outputs.new_tag }}
+        run: |
+          # Download latest hook from upstream
+          UPSTREAM_HOOK=$(curl -fsSL "https://raw.githubusercontent.com/rtk-ai/rtk/${NEW_COMMIT}/hooks/claude/rtk-rewrite.sh")
+
+          if [ -z "$UPSTREAM_HOOK" ]; then
+            echo "WARNING: Could not download upstream hook. Keeping current version."
+            echo "hook_changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Build new hook with our header
+          {
+            echo '#!/usr/bin/env bash'
+            echo '# ---------------------------------------------------------------------------'
+            echo "# Source: rtk-ai/rtk hooks/claude/rtk-rewrite.sh"
+            echo "# Upstream: https://github.com/rtk-ai/rtk/blob/${NEW_COMMIT}/hooks/claude/rtk-rewrite.sh"
+            echo "# Pinned commit: ${NEW_COMMIT} (${NEW_TAG})"
+            echo '# License: Apache-2.0 (see THIRD_PARTY_NOTICES.md)'
+            echo '# This file is redistributed under Apache-2.0. Local modifications: header only.'
+            echo '# ---------------------------------------------------------------------------'
+            # Append upstream content, skipping the shebang line
+            echo "$UPSTREAM_HOOK" | tail -n +2
+          } > dot_claude/hooks/executable_rtk-rewrite.sh
+
+          # Check if hook actually changed (excluding header which always changes)
+          OLD_BODY=$(git show HEAD:dot_claude/hooks/executable_rtk-rewrite.sh 2>/dev/null | tail -n +9 || echo "")
+          NEW_BODY=$(tail -n +9 dot_claude/hooks/executable_rtk-rewrite.sh)
+
+          if [ "$OLD_BODY" = "$NEW_BODY" ]; then
+            echo "Hook body unchanged (only header updated)"
+            echo "hook_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Hook body has changed!"
+            echo "hook_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update THIRD_PARTY_NOTICES.md
+        env:
+          NEW_COMMIT: ${{ needs.check-update.outputs.new_commit }}
+          NEW_TAG: ${{ needs.check-update.outputs.new_tag }}
+        run: |
+          # Update pinned commit reference
+          sed -i "s/Pinned commit: [a-f0-9]* (v[0-9.]*)/Pinned commit: ${NEW_COMMIT} (${NEW_TAG})/" THIRD_PARTY_NOTICES.md
+
+      - name: Update README badges
+        env:
+          NEW_TAG: ${{ needs.check-update.outputs.new_tag }}
+        run: |
+          # Update pinned version badge
+          sed -i "s|rtk%20pinned-v[0-9.]*-blue|rtk%20pinned-${NEW_TAG}-blue|" README.md
+
+      - name: Lint hook script (supply chain security)
+        id: lint-hook
+        run: |
+          SUSPICIOUS=false
+          HOOK=dot_claude/hooks/executable_rtk-rewrite.sh
+
+          # Check for dangerous patterns
+          PATTERNS=(
+            'curl\s'
+            'wget\s'
+            'nc\s'
+            'ncat\s'
+            'netcat\s'
+            'base64\s+-d'
+            'base64\s+--decode'
+            '\beval\b'
+            '\bexec\b'
+            'python[23]?\s+-c'
+            'ruby\s+-e'
+            'perl\s+-e'
+            'bash\s+-c'
+            '/dev/tcp/'
+            'ANTHROPIC_API_KEY'
+            'CLAUDE_API_KEY'
+            'Authorization:'
+          )
+
+          echo "=== Supply Chain Security Lint ==="
+          for PATTERN in "${PATTERNS[@]}"; do
+            # Skip legitimate uses (e.g., `command -v`)
+            if grep -Pn "$PATTERN" "$HOOK" | grep -v '^\d*:\s*#' | grep -v "command -v"; then
+              echo "Suspicious pattern found: $PATTERN"
+              SUSPICIOUS=true
+            fi
+          done
+
+          if [ "$SUSPICIOUS" = "true" ]; then
+            echo "suspicious=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Suspicious patterns detected in hook script. Review carefully!"
+          else
+            echo "No suspicious patterns found."
+            echo "suspicious=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ needs.check-update.outputs.new_version }}
+          NEW_TAG: ${{ needs.check-update.outputs.new_tag }}
+          NEW_COMMIT: ${{ needs.check-update.outputs.new_commit }}
+          PUBLISHED_AT: ${{ needs.check-update.outputs.published_at }}
+          DAYS_SINCE: ${{ needs.check-update.outputs.days_since_release }}
+          HOOK_CHANGED: ${{ steps.update-hook.outputs.hook_changed }}
+          SUSPICIOUS: ${{ steps.lint-hook.outputs.suspicious }}
+          FORCE_PR: ${{ inputs.force_pr || 'false' }}
+        run: |
+          BRANCH="rtk-update/${NEW_TAG}"
+
+          # Check if PR already exists
+          EXISTING=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING" ] && [ "$FORCE_PR" != "true" ]; then
+            echo "PR #$EXISTING already exists for $BRANCH. Skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add rtk/manifest.json dot_claude/hooks/executable_rtk-rewrite.sh THIRD_PARTY_NOTICES.md README.md
+          git commit -m "chore(rtk): update to ${NEW_TAG}
+
+          Automated update from rtk-ai/rtk.
+          Release: ${NEW_TAG} (${PUBLISHED_AT}, ${DAYS_SINCE} days ago)
+          Commit: ${NEW_COMMIT}"
+
+          git push origin "$BRANCH" --force-with-lease
+
+          # Build PR body
+          LABELS="dependencies,automated"
+          if [ "$SUSPICIOUS" = "true" ]; then
+            LABELS="$LABELS,⚠️ suspicious"
+          fi
+          if [ "$HOOK_CHANGED" = "true" ]; then
+            LABELS="$LABELS,hook-changed"
+          fi
+
+          BODY="## rtk ${NEW_TAG} update
+
+          **Release**: [${NEW_TAG}](https://github.com/rtk-ai/rtk/releases/tag/${NEW_TAG})
+          **Commit**: [\`${NEW_COMMIT:0:7}\`](https://github.com/rtk-ai/rtk/commit/${NEW_COMMIT})
+          **Published**: ${PUBLISHED_AT} (${DAYS_SINCE} days ago, cooldown: 7 days)
+
+          ### Changes
+          - \`rtk/manifest.json\`: version + sha256 updated
+          - \`dot_claude/hooks/executable_rtk-rewrite.sh\`: header updated"
+
+          if [ "$HOOK_CHANGED" = "true" ]; then
+            BODY="$BODY
+          - **Hook body changed** -- review the diff carefully"
+          fi
+
+          if [ "$SUSPICIOUS" = "true" ]; then
+            BODY="$BODY
+
+          ### Supply Chain Security Warning
+          Suspicious patterns detected in the updated hook script. **Do NOT merge** without thorough manual review."
+          fi
+
+          BODY="$BODY
+
+          ### Supply Chain Security Checklist
+          - [ ] Reviewed manifest.json sha256 values
+          - [ ] Reviewed hook script diff (body changes: ${HOOK_CHANGED})
+          - [ ] Checked [upstream changelog](https://github.com/rtk-ai/rtk/releases/tag/${NEW_TAG})
+          - [ ] Suspicious patterns: ${SUSPICIOUS}
+
+          ### Verify locally
+          \`\`\`bash
+          git checkout ${BRANCH}
+          nix build .#default --no-link --print-out-paths
+          # test: \$(nix build .#default --no-link --print-out-paths)/bin/rtk --version
+          \`\`\`
+          "
+
+          # Create labels if they don't exist (ignore errors)
+          gh label create "dependencies" --color "0366d6" --description "Dependency updates" 2>/dev/null || true
+          gh label create "automated" --color "ededed" --description "Automated PRs" 2>/dev/null || true
+          gh label create "⚠️ suspicious" --color "d93f0b" --description "Supply chain security warning" 2>/dev/null || true
+          gh label create "hook-changed" --color "fbca04" --description "Hook script body changed" 2>/dev/null || true
+
+          gh pr create \
+            --title "chore(rtk): update to ${NEW_TAG}" \
+            --body "$BODY" \
+            --label "$LABELS" \
+            --base main \
+            --head "$BRANCH"
+
+  reproducibility-check:
+    needs: [check-update, update-manifest]
+    if: needs.check-update.outputs.has_update == 'true' && needs.check-update.outputs.cooldown_met == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: rtk-update/${{ needs.check-update.outputs.new_tag }}
+
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build and verify rtk binary
+        env:
+          NEW_VERSION: ${{ needs.check-update.outputs.new_version }}
+        run: |
+          OUT=$(nix build .#default --no-link --print-out-paths)
+          BUILT_VERSION=$("$OUT"/bin/rtk --version 2>&1)
+          echo "Built version: $BUILT_VERSION"
+
+          if echo "$BUILT_VERSION" | grep -q -- "$NEW_VERSION"; then
+            echo "Version matches: $BUILT_VERSION"
+          else
+            echo "Version mismatch! Expected $NEW_VERSION, got $BUILT_VERSION"
+            exit 1
+          fi
+
+      - name: Post build result to PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_TAG: ${{ needs.check-update.outputs.new_tag }}
+        run: |
+          BRANCH="rtk-update/${NEW_TAG}"
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
+          if [ -n "$PR_NUMBER" ]; then
+            if [ "${{ job.status }}" = "success" ]; then
+              gh pr comment "$PR_NUMBER" --body "Reproducibility check passed. Nix build succeeded and version matches."
+            else
+              gh pr comment "$PR_NUMBER" --body "Reproducibility check failed. Please investigate before merging."
+            fi
+          fi

--- a/README.md
+++ b/README.md
@@ -326,3 +326,17 @@ NOTE: markdownlintによるチェックとの違いは要検証
 
 - マイグレーション履歴は [MIGRATION.md](MIGRATION.md) を参照
 - 機能拡張や問題報告は Issues へ
+
+## Credits
+
+- [rtk-ai/rtk](https://github.com/rtk-ai/rtk) — Claude Code のトークン削減フック。
+  Apache-2.0 で再配布 (詳細は [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md))。
+
+### rtk バージョン状態
+
+<!-- rtk-status-badges:start -->
+![rtk pinned](https://img.shields.io/badge/rtk%20pinned-v0.36.0-blue)
+![rtk upstream](https://img.shields.io/github/v/release/rtk-ai/rtk?label=rtk%20upstream)
+<!-- rtk-status-badges:end -->
+
+(cooldown バッジは GitHub Actions 設定後に追加予定)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,213 @@
+# Third-Party Notices
+
+このリポジトリは以下の第三者ソフトウェアのファイルを再配布しています。
+
+## rtk (Rust Token Killer)
+
+- Source: <https://github.com/rtk-ai/rtk>
+- Pinned commit: `a69935746172d913fcbd282d720d2daf5025e5e9` (v0.36.0)
+- License: Apache-2.0 (LICENSE ファイル基準)
+  - 注意: upstream の Cargo.toml では "MIT" と記載されており、ライセンス表記に
+    不整合があります。本リポジトリでは要件のより厳格な Apache-2.0 を準拠基準とし、
+    全文を以下に同梱します。upstream への確認は別途実施予定。
+- Copyright: Patrick Szymkowiak
+
+再配布ファイル:
+
+- `dot_claude/hooks/executable_rtk-rewrite.sh` (元: `hooks/claude/rtk-rewrite.sh`)
+- `dot_config/rtk/filters.toml` (元: `.rtk/filters.toml`)
+
+### Apache License 2.0 全文
+
+```text
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 rtk-ai and rtk-ai Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```

--- a/dot_claude/hooks/executable_rtk-rewrite.sh
+++ b/dot_claude/hooks/executable_rtk-rewrite.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Source: rtk-ai/rtk hooks/claude/rtk-rewrite.sh
+# Upstream: https://github.com/rtk-ai/rtk/blob/a69935746172d913fcbd282d720d2daf5025e5e9/hooks/claude/rtk-rewrite.sh
+# Pinned commit: a69935746172d913fcbd282d720d2daf5025e5e9 (v0.36.0)
+# License: Apache-2.0 (see THIRD_PARTY_NOTICES.md)
+# This file is redistributed under Apache-2.0. Local modifications: header only.
+# ---------------------------------------------------------------------------
+# rtk-hook-version: 3
+# RTK Claude Code hook — rewrites commands to use rtk for token savings.
+# Requires: rtk >= 0.23.0, jq
+#
+# This is a thin delegating hook: all rewrite logic lives in `rtk rewrite`,
+# which is the single source of truth (src/discover/registry.rs).
+# To add or change rewrite rules, edit the Rust registry — not this file.
+#
+# Exit code protocol for `rtk rewrite`:
+#   0 + stdout  Rewrite found, no deny/ask rule matched → auto-allow
+#   1           No RTK equivalent → pass through unchanged
+#   2           Deny rule matched → pass through (Claude Code native deny handles it)
+#   3 + stdout  Ask rule matched → rewrite but let Claude Code prompt the user
+
+if ! command -v jq &>/dev/null; then
+  echo "[rtk] WARNING: jq is not installed. Hook cannot rewrite commands. Install jq: https://jqlang.github.io/jq/download/" >&2
+  exit 0
+fi
+
+if ! command -v rtk &>/dev/null; then
+  echo "[rtk] WARNING: rtk is not installed or not in PATH. Hook cannot rewrite commands. Install: https://github.com/rtk-ai/rtk#installation" >&2
+  exit 0
+fi
+
+# Version guard: rtk rewrite was added in 0.23.0.
+# Older binaries: warn once and exit cleanly (no silent failure).
+# Cache the version check to avoid spawning multiple processes on every hook call.
+CACHE_DIR=${XDG_CACHE_HOME:-$HOME/.cache}
+CACHE_FILE="$CACHE_DIR/rtk-hook-version-ok"
+if [ ! -f "$CACHE_FILE" ]; then
+  RTK_VERSION_RAW=$(rtk --version 2>/dev/null)
+  RTK_VERSION=${RTK_VERSION_RAW#rtk }
+  RTK_VERSION=${RTK_VERSION%% *}
+  if [ -n "$RTK_VERSION" ]; then
+    IFS=. read -r MAJOR MINOR PATCH <<<"$RTK_VERSION"
+    # Require >= 0.23.0
+    if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 23 ]; then
+      echo "[rtk] WARNING: rtk $RTK_VERSION is too old (need >= 0.23.0). Upgrade: cargo install rtk" >&2
+      exit 0
+    fi
+  fi
+  mkdir -p "$CACHE_DIR" 2>/dev/null
+  touch "$CACHE_FILE" 2>/dev/null
+fi
+
+INPUT=$(cat)
+CMD=$(jq -r '.tool_input.command // empty' <<<"$INPUT")
+
+if [ -z "$CMD" ]; then
+  exit 0
+fi
+
+# Delegate all rewrite + permission logic to the Rust binary.
+REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
+EXIT_CODE=$?
+
+case $EXIT_CODE in
+  0)
+    # Rewrite found, no permission rules matched — safe to auto-allow.
+    # If the output is identical, the command was already using RTK.
+    [ "$CMD" = "$REWRITTEN" ] && exit 0
+    ;;
+  1)
+    # No RTK equivalent — pass through unchanged.
+    exit 0
+    ;;
+  2)
+    # Deny rule matched — let Claude Code's native deny rule handle it.
+    exit 0
+    ;;
+  3)
+    # Ask rule matched — rewrite the command but do NOT auto-allow so that
+    # Claude Code prompts the user for confirmation.
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+if [ "$EXIT_CODE" -eq 3 ]; then
+  # Ask: rewrite the command, omit permissionDecision so Claude Code prompts.
+  jq -c --arg cmd "$REWRITTEN" \
+    '.tool_input.command = $cmd | {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "updatedInput": .tool_input
+      }
+    }' <<<"$INPUT"
+else
+  # Allow: rewrite the command and auto-allow.
+  jq -c --arg cmd "$REWRITTEN" \
+    '.tool_input.command = $cmd | {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+        "permissionDecisionReason": "RTK auto-rewrite",
+        "updatedInput": .tool_input
+      }
+    }' <<<"$INPUT"
+fi

--- a/dot_claude/settings.json.src
+++ b/dot_claude/settings.json.src
@@ -121,6 +121,17 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/rtk-rewrite.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "",

--- a/dot_config/rtk/filters.toml
+++ b/dot_config/rtk/filters.toml
@@ -1,0 +1,20 @@
+# ---------------------------------------------------------------------------
+# Template based on: rtk-ai/rtk .rtk/filters.toml
+# Upstream: https://github.com/rtk-ai/rtk/blob/a69935746172d913fcbd282d720d2daf5025e5e9/.rtk/filters.toml
+# License: Apache-2.0 (see THIRD_PARTY_NOTICES.md)
+# This is the user-global filter config. Override per-project filters live in
+# <repo>/.rtk/filters.toml and require `rtk trust`.
+# ---------------------------------------------------------------------------
+# Project-local RTK filters — commit this file with your repo.
+# Filters here override user-global and built-in filters.
+# Docs: https://github.com/rtk-ai/rtk#custom-filters
+schema_version = 1
+
+# Example: suppress build noise from a custom tool
+# [filters.my-tool]
+# description = "Compact my-tool output"
+# match_command = "^my-tool\\s+build"
+# strip_ansi = true
+# strip_lines_matching = ["^\\s*$", "^Downloading", "^Installing"]
+# max_lines = 30
+# on_empty = "my-tool: ok"

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,32 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        rtkManifest = builtins.fromJSON (builtins.readFile ./rtk/manifest.json);
+        rtkPlatform = rtkManifest.platforms.${system} or null;
+        rtk =
+          if rtkPlatform == null then null
+          else pkgs.stdenvNoCC.mkDerivation {
+            pname = "rtk";
+            version = rtkManifest.version;
+            src = pkgs.fetchurl {
+              url = "${rtkManifest.repository}/releases/download/${rtkManifest.tag}/rtk-${rtkPlatform.target}.tar.gz";
+              sha256 = rtkPlatform.sha256;
+            };
+            sourceRoot = ".";
+            nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+            installPhase = ''
+              runHook preInstall
+              install -Dm755 rtk $out/bin/rtk
+              runHook postInstall
+            '';
+            meta = with pkgs.lib; {
+              description = "Rust Token Killer - reduce LLM token consumption via command rewriting";
+              homepage = rtkManifest.repository;
+              license = licenses.asl20;
+              platforms = builtins.attrNames rtkManifest.platforms;
+              mainProgram = "rtk";
+            };
+          };
       in
       {
         # Main package output for user-wide installation
@@ -70,7 +96,7 @@
 
             # Linters
             actionlint        # GitHub Actions workflow linter
-          ];
+          ] ++ pkgs.lib.optional (rtk != null) rtk;
         };
       }
     );

--- a/rtk/manifest.json
+++ b/rtk/manifest.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.36.0",
+  "commit": "a69935746172d913fcbd282d720d2daf5025e5e9",
+  "tag": "v0.36.0",
+  "repository": "https://github.com/rtk-ai/rtk",
+  "platforms": {
+    "x86_64-linux": {
+      "target": "x86_64-unknown-linux-musl",
+      "sha256": "2d428ce344734df95e0933f01f30a2d694fad470de39d8c5186b89eb707aac26"
+    },
+    "aarch64-linux": {
+      "target": "aarch64-unknown-linux-gnu",
+      "sha256": "ec0cc96a6e483399943d7c9948196716d04de7ee4a1b07fe7bafe2b183197826"
+    },
+    "x86_64-darwin": {
+      "target": "x86_64-apple-darwin",
+      "sha256": "5a874af307fa768ea0e30fbc1f35f26be8108f076da3aea2836bb3a6f99e5dcf"
+    },
+    "aarch64-darwin": {
+      "target": "aarch64-apple-darwin",
+      "sha256": "d80041c5773b4a0981d186a87f37b1543cba41cf1d1f53d3b5f2165c8d16f1e2"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **rtk v0.36.0** (Rust Token Killer) を Claude Code の PreToolUse hook として統合。Bash コマンド出力を圧縮し、トークン消費を 60-90% 削減
- Nix flake でバイナリ管理、`rtk/manifest.json` に版情報を外出しして CI 更新を容易に
- GitHub Actions で**週次自動更新 PR** (7日 cooldown + hook 静的検査 + Nix 再現性ビルド + 手動 merge)

## Changes (8 files, +789 lines)
- `flake.nix` + `rtk/manifest.json` — Nix でのバイナリ配備 (4 platform 対応)
- `dot_claude/hooks/executable_rtk-rewrite.sh` — PreToolUse hook (upstream コピー + 由来ヘッダー)
- `dot_claude/settings.json.src` — PreToolUse hook 登録
- `dot_config/rtk/filters.toml` — グローバルフィルタテンプレート
- `THIRD_PARTY_NOTICES.md` — Apache-2.0 ライセンス全文 (再配布義務)
- `README.md` — Credits セクション + バージョンバッジ
- `.github/workflows/rtk-update-check.yml` — 自動更新ワークフロー

## Supply chain defense
| 層 | 対策 |
| --- | --- |
| Pin | commit SHA + sha256 (manifest.json) |
| Cooldown | リリースから 7 日経過後に PR 作成 |
| Lint | hook スクリプトに対し 17 種の危険パターン検出 |
| Review | 手動 merge 必須、hook body 変更時は専用ラベル |
| Reproducibility | Nix ビルド + version 一致確認 |

## Test plan
- [x] `nix build .#default` 成功、`rtk --version` → `rtk 0.36.0`
- [x] `chezmoi apply` で hook / settings.json / filters.toml 配備確認
- [x] hook テスト: `git status` → `rtk git status` に正しく書き換え
- [x] 対象外コマンド (`echo hello`) はスルー確認
- [x] actionlint エラー 0 件
- [ ] main マージ後 `nix profile upgrade chezmoi` で rtk が PATH に入ること
- [ ] Claude Code 再起動で hook 有効化確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)