### PR TITLE
Add anthropics skills via gh skill, drop document-skills plugin

### DIFF
--- a/dot_claude/run_once_after_install_agent_skills.sh.tmpl
+++ b/dot_claude/run_once_after_install_agent_skills.sh.tmpl
@@ -2,18 +2,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install user-global agent skills from ebal5/agent-skills.
-# Bumping PIN changes this file's content hash, so chezmoi will re-run
+# Install user-global agent skills.
+# Bumping a PIN changes this file's content hash, so chezmoi will re-run
 # this script and pick up the new version on next apply.
 
-REPO="ebal5/agent-skills"
-PIN="v0.1.0"
-SKILLS=(dev-workflow grill-me handover markdown-check uv-script)
+# ebal5/agent-skills — own repo with semver tags
+OWN_REPO="ebal5/agent-skills"
+OWN_PIN="v0.1.0"
+OWN_SKILLS=(dev-workflow grill-me handover markdown-check uv-script)
 
-for skill in "${SKILLS[@]}"; do
-  echo ">> gh skill install ${REPO} ${skill} --pin ${PIN}"
-  gh skill install "${REPO}" "${skill}" \
-    --agent claude-code --scope user --pin "${PIN}" --force
+for skill in "${OWN_SKILLS[@]}"; do
+  echo ">> gh skill install ${OWN_REPO} ${skill} --pin ${OWN_PIN}"
+  gh skill install "${OWN_REPO}" "${skill}" \
+    --agent claude-code --scope user --pin "${OWN_PIN}" --force
+done
+
+# anthropics/skills — upstream has no release tags, pin by commit SHA
+UPSTREAM_REPO="anthropics/skills"
+UPSTREAM_PIN="2c7ec5e78b8e5d43ea02e90bb8826f6b9f147b0c"
+UPSTREAM_SKILLS=(skill-creator mcp-builder pdf doc-coauthoring)
+
+for skill in "${UPSTREAM_SKILLS[@]}"; do
+  echo ">> gh skill install ${UPSTREAM_REPO} ${skill} --pin ${UPSTREAM_PIN:0:8}"
+  gh skill install "${UPSTREAM_REPO}" "${skill}" \
+    --agent claude-code --scope user --pin "${UPSTREAM_PIN}" --force
 done
 {{ else -}}
 #!/usr/bin/env bash

--- a/dot_claude/settings.json.src
+++ b/dot_claude/settings.json.src
@@ -203,19 +203,10 @@
   },
   "enabledPlugins": {
     "commit-commands@claude-plugins-official": true,
-    "document-skills@anthropic-agent-skills": true,
     "feature-dev@claude-plugins-official": true,
     "agent-sdk-dev@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true
-  },
-  "extraKnownMarketplaces": {
-    "anthropic-agent-skills": {
-      "source": {
-        "source": "github",
-        "repo": "anthropics/skills"
-      }
-    }
   },
   "alwaysThinkingEnabled": true,
   "teammateMode": "tmux",


### PR DESCRIPTION
## Summary
- `anthropics/skills` から `skill-creator` / `mcp-builder` / `pdf` / `doc-coauthoring` の 4 スキルを `gh skill install` で user scope に導入
- これらは commit SHA (`2c7ec5e78b8e5d43ea02e90bb8826f6b9f147b0c`) でピン留め（upstream が tag を持たないため）
- `document-skills@anthropic-agent-skills` plugin を無効化 + marketplace 登録を削除
- 使用頻度が低い 12 スキル（xlsx/docx/pptx/frontend-design/brand-guidelines 等）を context から除外

## 背景
`gh skill install` (gh 2.90.0+) で必要なスキルだけ個別に install できることを確認。既存の agent-skills 運用に統合することで skill 管理を1箇所に集約する。

## Test plan
- [ ] chezmoi diff で settings.json と run_once スクリプトのみが変更対象
- [ ] chezmoi apply 後に `~/.claude/skills/` に 9 スキル全部存在
- [ ] `jq '.enabledPlugins' ~/.claude/settings.json` から document-skills@anthropic-agent-skills が消えている
- [ ] Claude Code 再起動後、`document-skills:*` スキル群がスキル一覧から消えること
- [ ] 代わりに skill-creator 等が namespace なしで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)