### PR TITLE
Bump agent-skills pin to v0.2.1 and dedup skill list

### DIFF
--- a/dot_claude/run_once_after_install_agent_skills.sh.tmpl
+++ b/dot_claude/run_once_after_install_agent_skills.sh.tmpl
@@ -10,7 +10,7 @@ set -euo pipefail
 # Skill list is fetched from install-sets/common.txt at the pinned ref so
 # agent-skills stays the single source of truth; bump OWN_PIN to refresh.
 OWN_REPO="ebal5/agent-skills"
-OWN_PIN="v0.2.0"
+OWN_PIN="v0.2.1"
 mapfile -t OWN_SKILLS < <(
   gh api "repos/${OWN_REPO}/contents/install-sets/common.txt?ref=${OWN_PIN}" \
     --jq '.content' | base64 -d \

--- a/dot_claude/run_once_after_install_agent_skills.sh.tmpl
+++ b/dot_claude/run_once_after_install_agent_skills.sh.tmpl
@@ -6,10 +6,16 @@ set -euo pipefail
 # Bumping a PIN changes this file's content hash, so chezmoi will re-run
 # this script and pick up the new version on next apply.
 
-# ebal5/agent-skills — own repo with semver tags
+# ebal5/agent-skills — own repo with semver tags.
+# Skill list is fetched from install-sets/common.txt at the pinned ref so
+# agent-skills stays the single source of truth; bump OWN_PIN to refresh.
 OWN_REPO="ebal5/agent-skills"
-OWN_PIN="v0.1.0"
-OWN_SKILLS=(dev-workflow grill-me handover markdown-check uv-script)
+OWN_PIN="v0.2.0"
+mapfile -t OWN_SKILLS < <(
+  gh api "repos/${OWN_REPO}/contents/install-sets/common.txt?ref=${OWN_PIN}" \
+    --jq '.content' | base64 -d \
+    | awk '/^[[:space:]]*#/ || /^[[:space:]]*$/ {next} {print $1}'
+)
 
 for skill in "${OWN_SKILLS[@]}"; do
   echo ">> gh skill install ${OWN_REPO} ${skill} --pin ${OWN_PIN}"


### PR DESCRIPTION
## Summary

- Bumps `OWN_PIN` from `v0.1.0` to `v0.2.0` in the agent-skills install hook
- Replaces the hardcoded `OWN_SKILLS=(...)` list with a `gh api` fetch of `install-sets/common.txt` at `OWN_PIN`, so `ebal5/agent-skills` is the single source of truth for the "what lands on every machine" list
- v0.2.0 adds `review-loop` and `execute-script-safely` to the common profile — after this lands they will auto-install on every machine on the next `chezmoi apply`

## Test plan

- [x] `chezmoi execute-template < dot_claude/run_once_after_install_agent_skills.sh.tmpl` renders without error
- [x] Rendered script passes `bash -n`
- [x] The fetch logic run standalone returns the expected 7 skills (dev-workflow, execute-script-safely, grill-me, handover, markdown-check, review-loop, uv-script)
- [ ] After merge, `chezmoi apply` on a machine pinned to v0.1.0 re-runs the hook (content hash changed) and installs the two new skills

## Notes

- Requires bash 4+ for `mapfile`. All target machines use modern bash so this is fine; flag if a system bash 3.x host pops up
- `anthropics/skills` section untouched — that upstream has no release tags and pins by commit SHA, so the dedup pattern doesn't apply there

🤖 Generated with [Claude Code](https://claude.com/claude-code)