### PR TITLE
Add zellij, watchexec, and neovim to nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
             sd                # sed replacement
             hyperfine         # Benchmarking tool
             xh                # HTTP client (httpie replacement)
+            watchexec         # File-watch command executor
 
             # Python ecosystem
             uv                # Fast Python package installer
@@ -83,6 +84,10 @@
             oxker             # Docker container TUI manager
             ov                # Feature-rich terminal pager
             glow              # Terminal Markdown renderer
+            zellij            # Terminal workspace / multiplexer
+
+            # Editors
+            neovim            # Hyperextensible Vim-based editor
 
             # Task management
             pueue             # CLI task queue manager


### PR DESCRIPTION
## Summary
- `watchexec` を Rust-based CLI tools セクションに追加
- `zellij` を TUI tools セクションに追加
- `neovim` 用に新規 "Editors" セクションを作成

## Test plan
- [ ] CI のビルド/lint をパス
- [ ] `nix build .#default` がローカルで成功
- [ ] apply 後に `zellij`, `watchexec`, `nvim` が PATH に出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)