### PR TITLE
feat(git): add wrf/wrff aliases for fzf-based worktree removal

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -96,9 +96,9 @@
 	fco = !git branch --all | grep -v HEAD | sed 's|^[* ] ||' | sed 's|remotes/origin/||' | sort -u | fzf | xargs git checkout  # fzfでブランチ選択・チェックアウト
 	flog = !git log --oneline | fzf | awk '{print $1}' | xargs git show  # fzfでコミット選択・表示
 
-	# worktree管理
-	wrf = !git worktree list | tail -n +2 | fzf -m --prompt=\"remove> \" | awk '{print $1}' | xargs -r -n1 git worktree remove  # fzfでworktree選択・削除
-	wrff = !git worktree list | tail -n +2 | fzf -m --prompt=\"remove(force)> \" | awk '{print $1}' | xargs -r -n1 git worktree remove --force  # fzfでworktree選択・強制削除
+	# worktree管理（--porcelainで解析しスペース・日本語パスにも対応）
+	wrf = !git worktree list --porcelain | awk '/^worktree /{p=substr($0,10)} /^branch /{b=substr($0,8)} /^detached/{b=\"detached\"} /^bare/{b=\"bare\"} /^$/{print p\"\\t\"b}' | tail -n +2 | fzf -m --prompt=\"remove> \" | cut -f1 | xargs -r -I{} git worktree remove {}  # fzfでworktree選択・削除
+	wrff = !git worktree list --porcelain | awk '/^worktree /{p=substr($0,10)} /^branch /{b=substr($0,8)} /^detached/{b=\"detached\"} /^bare/{b=\"bare\"} /^$/{print p\"\\t\"b}' | tail -n +2 | fzf -m --prompt=\"remove(force)> \" | cut -f1 | xargs -r -I{} git worktree remove --force {}  # fzfでworktree選択・強制削除
 
 [merge]
 	ff = false

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -96,6 +96,10 @@
 	fco = !git branch --all | grep -v HEAD | sed 's|^[* ] ||' | sed 's|remotes/origin/||' | sort -u | fzf | xargs git checkout  # fzfでブランチ選択・チェックアウト
 	flog = !git log --oneline | fzf | awk '{print $1}' | xargs git show  # fzfでコミット選択・表示
 
+	# worktree管理
+	wrf = !git worktree list | tail -n +2 | fzf -m --prompt=\"remove> \" | awk '{print $1}' | xargs -r -n1 git worktree remove  # fzfでworktree選択・削除
+	wrff = !git worktree list | tail -n +2 | fzf -m --prompt=\"remove(force)> \" | awk '{print $1}' | xargs -r -n1 git worktree remove --force  # fzfでworktree選択・強制削除
+
 [merge]
 	ff = false
 

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -97,8 +97,8 @@
 	flog = !git log --oneline | fzf | awk '{print $1}' | xargs git show  # fzfでコミット選択・表示
 
 	# worktree管理（--porcelainで解析しスペース・日本語パスにも対応）
-	wrf = !git worktree list --porcelain | awk '/^worktree /{p=substr($0,10)} /^branch /{b=substr($0,8)} /^detached/{b=\"detached\"} /^bare/{b=\"bare\"} /^$/{print p\"\\t\"b}' | tail -n +2 | fzf -m --prompt=\"remove> \" | cut -f1 | xargs -r -I{} git worktree remove {}  # fzfでworktree選択・削除
-	wrff = !git worktree list --porcelain | awk '/^worktree /{p=substr($0,10)} /^branch /{b=substr($0,8)} /^detached/{b=\"detached\"} /^bare/{b=\"bare\"} /^$/{print p\"\\t\"b}' | tail -n +2 | fzf -m --prompt=\"remove(force)> \" | cut -f1 | xargs -r -I{} git worktree remove --force {}  # fzfでworktree選択・強制削除
+	wrf = !git worktree list --porcelain | awk '/^worktree /{p=substr($0,10)} /^branch /{b=substr($0,8)} /^detached/{b=$0} /^bare/{b=$0} /^$/{print b, p}' | tail -n +2 | fzf -m --prompt='remove> ' | cut -d' ' -f2- | xargs -r -I{} git worktree remove {}  # fzfでworktree選択・削除
+	wrff = !git worktree list --porcelain | awk '/^worktree /{p=substr($0,10)} /^branch /{b=substr($0,8)} /^detached/{b=$0} /^bare/{b=$0} /^$/{print b, p}' | tail -n +2 | fzf -m --prompt='remove(force)> ' | cut -d' ' -f2- | xargs -r -I{} git worktree remove --force {}  # fzfでworktree選択・強制削除
 
 [merge]
 	ff = false


### PR DESCRIPTION
## Summary

- `dot_gitconfig.tmpl` のfzf連携セクションに、worktreeをfzfで選択削除するgitエイリアス `wrf` / `wrff` を追加
- `wrf`: 通常削除（`git worktree remove`）／ `wrff`: `--force` 付き削除
- スペースや日本語を含むworktreeパスでも安全に動作するよう実装

## 実装詳細

`git worktree list --porcelain` で機械可読フォーマットからworktreeパスを行単位で取得し、awk で `ブランチ名 パス` に整形。fzf で複数選択後、`cut -d' ' -f2-` でパスを抽出し、`xargs -r -I{}` で改行区切り削除する。

これにより `awk '{print $1}'` によるスペース分割の問題を回避し、スペース・日本語パスでも安全に削除できる。fzf 表示にはブランチ名も併記される。

awk の文字列リテラル（`""`）・タブ（`\t`）を排除したため、gitconfig 値とシェルに渡るコマンドが完全一致する。エスケープが不要で、下記のコマンドはそのまま端末に貼り付けて実行できる。

## ターミナルで直接実行する場合

エイリアスを使わず、その場で実行したいときは以下をそのまま貼り付ける。

通常削除（`wrf` 相当）:

```sh
git worktree list --porcelain | awk '/^worktree /{p=substr($0,10)} /^branch /{b=substr($0,8)} /^detached/{b=$0} /^bare/{b=$0} /^$/{print b, p}' | tail -n +2 | fzf -m --prompt='remove> ' | cut -d' ' -f2- | xargs -r -I{} git worktree remove {}
```

強制削除（`wrff` 相当、`--force` 付き）:

```sh
git worktree list --porcelain | awk '/^worktree /{p=substr($0,10)} /^branch /{b=substr($0,8)} /^detached/{b=$0} /^bare/{b=$0} /^$/{print b, p}' | tail -n +2 | fzf -m --prompt='remove(force)> ' | cut -d' ' -f2- | xargs -r -I{} git worktree remove --force {}
```

## Test plan

- [x] スペース付きパス（`/tmp/wt space テスト`）・日本語パス（`/tmp/wt2_日本語パス`）のworktreeを作成し、gitエイリアスとして end-to-end で削除動作を確認
- [x] gitconfig 値とシェルに渡るコマンドが一致することを `git config --get` で確認
- [ ] `chezmoi apply` 後、実環境で `git wrf` / `git wrff` を実行

https://claude.ai/code/session_017nnQcmAr8A3zQ2Y7akX9an