### PR TITLE
feat(zsh): standaloneプロンプト追加とvimモード導入

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -11,6 +11,9 @@
 # Superpowers docs - 設計ドキュメント
 docs/
 
+# Extra snippets - chezmoi管轄外のスニペット置き場（必要時に手動で利用）
+extras/
+
 # Development and maintenance files - 開発・メンテナンス用ファイル
 .gitignore
 .github/

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -12,6 +12,13 @@ ap-northeast-1 = "ap-ne-1"
 [azure]
 format = '[\[$symbol($subscription)\]]($style) '
 
+[character]
+# Vi モードのインジケータ（dot_zshrc の bindkey -v と連動）
+# insert/成否は ❯ の色で、normal モードは赤の Vim ロゴで表示
+success_symbol = '[❯](green)'
+error_symbol = '[❯](red)'
+vicmd_symbol = '[](red)'
+
 [cmd_duration]
 min_time = 5_000  # Show command duration over 5,000 milliseconds (=5 sec)
 show_milliseconds = true

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -21,6 +21,22 @@ setopt AUTO_CD
 setopt EXTENDED_GLOB
 setopt NO_BEEP
 
+# Vi mode
+# 以降の bindkey（mcfly/WSL）が viins キーマップに束縛されるよう、早い段階で有効化する
+bindkey -v
+# Esc からノーマルモードへの切替を高速化（ミリ秒）
+export KEYTIMEOUT=1
+# Vi モードでも使い慣れた Emacs 風キーを insert モードに残す（操作性維持）
+bindkey -M viins '^A' beginning-of-line
+bindkey -M viins '^E' end-of-line
+bindkey -M viins '^K' kill-line
+bindkey -M viins '^U' backward-kill-line
+bindkey -M viins '^W' backward-kill-word
+bindkey -M viins '^Y' yank
+bindkey -M viins '^?' backward-delete-char
+bindkey -M viins '^H' backward-delete-char
+# Ctrl-R は mcfly / 標準履歴検索に委譲する
+
 # Completion system
 autoload -Uz compinit
 compinit -C
@@ -68,6 +84,13 @@ command -v zoxide >/dev/null 2>&1 && eval "$(zoxide init zsh)"
 [[ -e "$HOME/.config/sh-like-aliases" ]] && . "$HOME/.config/sh-like-aliases"
 
 command -v starship >/dev/null 2>&1 && eval "$(starship init zsh)"
+
+# Vi モード切替時にプロンプトを再描画し、starship の character モジュール
+# （vicmd_symbol）でノーマル/インサートのインジケータを反映させる
+function zle-keymap-select() {
+  zle reset-prompt
+}
+zle -N zle-keymap-select
 
 # mcfly
 if command -v mcfly >/dev/null 2>&1 && [[ -z "$MCFLY_LOADED" ]]; then

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -24,8 +24,10 @@ setopt NO_BEEP
 # Vi mode
 # 以降の bindkey（mcfly/WSL）が viins キーマップに束縛されるよう、早い段階で有効化する
 bindkey -v
-# Esc からノーマルモードへの切替を高速化（ミリ秒）
-export KEYTIMEOUT=1
+# Esc からノーマルモードへの切替を高速化（1/100秒単位）
+# SSH 等の高遅延環境で矢印/Ctrl-矢印などの ESC 始まりシーケンスが化けないよう
+# 過度に小さくせず 10（=100ms）にしておく
+export KEYTIMEOUT=10
 # Vi モードでも使い慣れた Emacs 風キーを insert モードに残す（操作性維持）
 bindkey -M viins '^A' beginning-of-line
 bindkey -M viins '^E' end-of-line
@@ -88,11 +90,22 @@ command -v zoxide >/dev/null 2>&1 && eval "$(zoxide init zsh)"
 command -v starship >/dev/null 2>&1 && eval "$(starship init zsh)"
 
 # Vi モード切替時にプロンプトを再描画し、starship の character モジュール
-# （vicmd_symbol）でノーマル/インサートのインジケータを反映させる
+# （vicmd_symbol）でノーマル/インサートのインジケータを反映させる。
+# あわせてカーソル形状も切替（normal=ブロック / insert=ビーム）。
 function zle-keymap-select() {
+  case $KEYMAP in
+    vicmd) print -n '\e[2 q' ;; # ブロックカーソル
+    *) print -n '\e[6 q' ;;     # ビーム（I字）カーソル
+  esac
   zle reset-prompt
 }
 zle -N zle-keymap-select
+
+# 各プロンプト開始時は insert から始まるためビームに戻す
+function zle-line-init() {
+  print -n '\e[6 q'
+}
+zle -N zle-line-init
 
 # mcfly
 if command -v mcfly >/dev/null 2>&1 && [[ -z "$MCFLY_LOADED" ]]; then

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -35,7 +35,9 @@ bindkey -M viins '^W' backward-kill-word
 bindkey -M viins '^Y' yank
 bindkey -M viins '^?' backward-delete-char
 bindkey -M viins '^H' backward-delete-char
-# Ctrl-R は mcfly / 標準履歴検索に委譲する
+# Ctrl-R: mcfly があれば後段の init が上書きする。無い環境向けに標準の
+# インクリメンタル履歴検索をフォールバックとして束縛しておく（viins 既定では未割当のため）
+bindkey -M viins '^R' history-incremental-search-backward
 
 # Completion system
 autoload -Uz compinit

--- a/extras/.editorconfig
+++ b/extras/.editorconfig
@@ -1,0 +1,7 @@
+# extras/ は chezmoi 管轄外のスニペット置き場。
+# zsh 専用構文（ネストしたパラメータ展開など）を含むため、
+# shfmt / shellcheck（CI の `shfmt -i 2 -ci -w .` と `shfmt -f .`）の対象から外す。
+root = true
+
+[*]
+ignore = true

--- a/extras/zsh-standalone-prompt/README.md
+++ b/extras/zsh-standalone-prompt/README.md
@@ -27,7 +27,7 @@ starship などの追加ツールを入れられない環境向けに、zsh の�
 | AWS | `AWS_PROFILE` をオレンジ表示 |
 | Terraform | `.terraform/environment` のワークスペースを紫表示 |
 | 実行時間 | 5秒以上のコマンドを黄色で `⌛ Ns` 表示 |
-| Vi モード | insert は緑のペン 󰏫 、normal は赤の Vim ロゴ |
+| Vi モード | insert=緑のペン 󰏫 +ビームカーソル、normal=赤の Vim ロゴ+ブロックカーソル |
 | 終了ステータス | 直前コマンドの成否で `❯` を緑/赤に切替 |
 
 ## starship 版との表示比較
@@ -48,7 +48,7 @@ starship 未インストール環境では `dot_zshrc` の starship 初期化が
 | メモリ使用率 | `memory_usage` で表示 | ✗ 省略 |
 | 言語ランタイム等 | 各モジュールが自動表示 | ✗ 省略 |
 | 実行時間 | 5秒以上を `⌛` 表示 | 同左 |
-| Vi モード | `character` の vicmd_symbol | 専用アイコン（insert 󰏫 / normal ） |
+| Vi モード | `character` の vicmd_symbol +カーソル形状 | 専用アイコン（insert 󰏫 / normal ）+カーソル形状 |
 | 終了ステータス | `❯` の色で成否 | `❯` の色で成否（モードアイコンと分離表示） |
 | C-a/C-e 等 | dot_zshrc 側で insert に付与 | prompt.sh 内で insert に付与 |
 

--- a/extras/zsh-standalone-prompt/README.md
+++ b/extras/zsh-standalone-prompt/README.md
@@ -30,8 +30,30 @@ starship などの追加ツールを入れられない環境向けに、zsh の�
 | Vi モード | insert は緑のペン 󰏫 、normal は赤の Vim ロゴ |
 | 終了ステータス | 直前コマンドの成否で `❯` を緑/赤に切替 |
 
-starship 版との差分として、`git_metrics`（追加/削除行数）や `memory_usage` などは
-標準機能だけでは再現が難しいため省略しています。
+## starship 版との表示比較
+
+通常設定（starship 利用時）と、この `prompt.sh`（starship 無し版）の表示差分は以下の通り。
+starship 未インストール環境では `dot_zshrc` の starship 初期化がスキップされ、
+この `prompt.sh` を読み込めば下表の「prompt.sh」列の見た目になる。
+
+| 要素 | starship 版（通常） | prompt.sh（無し版） |
+| --- | --- | --- |
+| 時刻 | `⌚[ HH:MM:SS ]` | 同左（同一書式） |
+| ディレクトリ | 直近2階層・home 🏠 | 同左 |
+| Git ブランチ | main/master 非表示 | 同左 |
+| Git 変更状態 | starship 既定の表示 | 未ステージ `!`/ステージ済 `+` |
+| Git 変更行数 | `git_metrics` で +/- 表示 | ✗ 省略（標準機能で再現困難） |
+| AWS | `[profile]` オレンジ | 同左 |
+| Terraform | `[workspace]` 紫 | 同左 |
+| メモリ使用率 | `memory_usage` で表示 | ✗ 省略 |
+| 言語ランタイム等 | 各モジュールが自動表示 | ✗ 省略 |
+| 実行時間 | 5秒以上を `⌛` 表示 | 同左 |
+| Vi モード | `character` の vicmd_symbol | 専用アイコン（insert 󰏫 / normal ） |
+| 終了ステータス | `❯` の色で成否 | `❯` の色で成否（モードアイコンと分離表示） |
+| C-a/C-e 等 | dot_zshrc 側で insert に付与 | prompt.sh 内で insert に付与 |
+
+`git_metrics`（追加/削除行数）や `memory_usage`、各種ランタイム表示などは
+zsh 標準機能だけでは再現が難しいため省略している。
 
 ## 使い方
 

--- a/extras/zsh-standalone-prompt/README.md
+++ b/extras/zsh-standalone-prompt/README.md
@@ -1,0 +1,60 @@
+# zsh 標準機能プロンプト（Starship 不要版）
+
+starship などの追加ツールを入れられない環境向けに、zsh の標準機能だけで
+[`dot_config/starship.toml`](../../dot_config/starship.toml) の見た目を
+できる限り再現したプロンプト設定（`prompt.sh`）です。
+
+主にお仕事 Mac での利用を想定していますが、Mac 特化の設定は含まれていません。
+
+## 位置づけ
+
+- このディレクトリは **chezmoi 管轄外**（`.chezmoiignore` で除外）です。
+  `chezmoi apply` ではホームディレクトリに展開されません。
+- 必要になったときに、手動でコピー or source して使うためのスニペット置き場です。
+
+## 前提
+
+- **Nerd Font** が必須です（  󰏫 󱇪 󱁢 などのアイコンを使用）。
+- zsh の標準機能（`vcs_info` / `prompt_subst`）のみで動作し、外部ツールに依存しません。
+
+## 再現している要素
+
+| 要素 | 内容 |
+| --- | --- |
+| 時刻 | `⌚[ HH:MM:SS ]`（淡いグレー） |
+| ディレクトリ | 直近2階層をシアン表示、home は 🏠 |
+| Git | ブランチ名（main/master は非表示）、未ステージ `!`/ステージ済み `+` |
+| AWS | `AWS_PROFILE` をオレンジ表示 |
+| Terraform | `.terraform/environment` のワークスペースを紫表示 |
+| 実行時間 | 5秒以上のコマンドを黄色で `⌛ Ns` 表示 |
+| Vi モード | insert は緑のペン 󰏫 、normal は赤の Vim ロゴ |
+| 終了ステータス | 直前コマンドの成否で `❯` を緑/赤に切替 |
+
+starship 版との差分として、`git_metrics`（追加/削除行数）や `memory_usage` などは
+標準機能だけでは再現が難しいため省略しています。
+
+## 使い方
+
+### 一時的に試す
+
+```sh
+source /path/to/dotfiles/extras/zsh-standalone-prompt/prompt.sh
+```
+
+### 常用する（starship が入っていない環境）
+
+マシン固有設定ファイル `~/.config/local/shellrc.local` から読み込むのが手軽です
+（このファイルはリポジトリ管理外で、`dot_zshrc` の末尾で source されます）。
+
+```sh
+# ~/.config/local/shellrc.local
+[[ -f "$HOME/path/to/prompt.sh" ]] && source "$HOME/path/to/prompt.sh"
+```
+
+`dot_zshrc` では starship が見つかったときだけ初期化されるため
+（`command -v starship >/dev/null 2>&1 && eval "$(starship init zsh)"`）、
+starship 未インストール環境ではこの `prompt.sh` がそのまま有効になります。
+
+> [!NOTE]
+> Vi モード自体は `dot_zshrc` 側でも標準で有効化されています（`bindkey -v`）。
+> この `prompt.sh` を読み込むとモードインジケータの表示込みで上書きされます。

--- a/extras/zsh-standalone-prompt/prompt.sh
+++ b/extras/zsh-standalone-prompt/prompt.sh
@@ -3,6 +3,7 @@
 # ==============================================================================
 
 autoload -Uz vcs_info
+autoload -Uz add-zsh-hook
 setopt prompt_subst
 
 # Viモードを有効化
@@ -73,9 +74,11 @@ function get_env_info() {
 }
 
 # 5. コマンド実行時間 (5秒以上で黄色)
-function preexec() {
+# 既存フックを潰さないよう add-zsh-hook で追加する（上書き型の precmd/preexec は使わない）
+function _prompt_timer_start() {
     timer=${timer:-$SECONDS}
 }
+add-zsh-hook preexec _prompt_timer_start
 
 # ==============================================================================
 # 6. Viモード＆終了ステータス完全分離（Nerd Font対応）
@@ -86,12 +89,14 @@ VIM_MODE_ICON="%F{green}󰏫%f"
 function zle-line-init zle-line-finish zle-keymap-select {
     case $KEYMAP in
         vicmd)
-            # ノーマルモード時：赤のVimロゴ
+            # ノーマルモード時：赤のVimロゴ＋ブロックカーソル
             VIM_MODE_ICON="%F{red}%f"
+            print -n '\e[2 q'
             ;;
         *)
-            # インサートモード時：緑のペンアイコン 󰏫
+            # インサートモード時：緑のペンアイコン 󰏫 ＋ビーム（I字）カーソル
             VIM_MODE_ICON="%F{green}󰏫%f"
+            print -n '\e[6 q'
             ;;
     esac
     zle reset-prompt
@@ -106,8 +111,8 @@ function get_return_status() {
     echo "%(?.%F{green}❯%f.%F{red}❯%f)"
 }
 
-# precmdでは元のGit情報取得とタイマー処理を継続
-function precmd() {
+# Git情報取得とタイマー処理（こちらも add-zsh-hook で追加）
+function _prompt_precmd() {
     vcs_info
     if [ "$timer" ]; then
         local duration=$(($SECONDS - $timer))
@@ -119,6 +124,7 @@ function precmd() {
         unset timer
     fi
 }
+add-zsh-hook precmd _prompt_precmd
 
 # ==============================================================================
 # プロンプトの組み立て

--- a/extras/zsh-standalone-prompt/prompt.sh
+++ b/extras/zsh-standalone-prompt/prompt.sh
@@ -1,0 +1,122 @@
+# ==============================================================================
+# お仕事Mac用：zsh標準機能プロンプト（Starshipカラー＋Viモード完全版）
+# ==============================================================================
+
+autoload -Uz vcs_info
+setopt prompt_subst
+
+# Viモードを有効化
+bindkey -v
+# Escを押したときの反応速度を爆速にする（ミリ秒指定）
+export KEYTIMEOUT=1
+
+# 1. 時刻 (淡いグレー)
+function get_time() {
+    echo "%F{242}⌚[ %* ]%f "
+}
+
+# 2. カレントディレクトリ (鮮やかなシアン。homeは🏠)
+function get_dir() {
+    # %2~ を評価してパスを取得し、~ を 🏠 に置換したあと、全体をシアン(%F{cyan})にする
+    echo "%F{cyan}${$(print -P "%2~")//\~/🏠}%f"
+}
+
+# 3. Git (マゼンタ。アイコンとブランチ名を強調)
+zstyle ':vcs_info:git:*' check-for-changes true
+zstyle ':vcs_info:git:*' formats '%b' '%u%c'
+zstyle ':vcs_info:git:*' actionformats '%b|%a' '%u%c'
+# 変更がある場合は赤文字で「!」や「+」を表示
+zstyle ':vcs_info:*' unstagedstr '%F{red}!%f'
+zstyle ':vcs_info:*' stagedstr '%F{green}+%f'
+
+function get_git_info() {
+    if [[ -n "$vcs_info_msg_0_" ]]; then
+        local branch="$vcs_info_msg_0_"
+        local git_status="$vcs_info_msg_1_"
+
+        if [[ "$branch" != "main" && "$branch" != "master" ]]; then
+            if [[ -n "$git_status" ]]; then
+                # 変更がある時はステータスも表示
+                echo "%F{magenta}[ $branch ($git_status)]%f "
+            else
+                echo "%F{magenta}[ $branch]%f "
+            fi
+        fi
+    fi
+}
+
+# 4. クライアント環境（AWSはオレンジ/ゴールド、Terraformは紫）
+function get_env_info() {
+    local env_str=""
+    # AWS Profile (208番: オレンジ)
+    if [[ -n "$AWS_PROFILE" ]]; then
+        env_str+="%F{208}[󱇪 $AWS_PROFILE]%f "
+    fi
+    # Terraform Workspace (105番: 綺麗なパープル)
+    if [[ -d .terraform && -f .terraform/environment ]]; then
+        local tf_ws=$(cat .terraform/environment 2>/dev/null)
+        if [[ -n "$tf_ws" ]]; then
+            env_str+="%F{105}[󱁢 $tf_ws]%f "
+        fi
+    fi
+    echo "${env_str}%f"
+}
+
+# 5. コマンド実行時間 (5秒以上で黄色)
+function preexec() {
+    timer=${timer:-$SECONDS}
+}
+
+# ==============================================================================
+# 6. Viモード＆終了ステータス完全分離（Nerd Font対応）
+# ==============================================================================
+# デフォルトのモードアイコン（緑のペン 󰏫 ）
+VIM_MODE_ICON="%F{green}󰏫%f"
+
+function zle-line-init zle-line-finish zle-keymap-select {
+    case $KEYMAP in
+        vicmd)
+            # ノーマルモード時：赤のVimロゴ
+            VIM_MODE_ICON="%F{red}%f"
+            ;;
+        *)
+            # インサートモード時：緑のペンアイコン 󰏫
+            VIM_MODE_ICON="%F{green}󰏫%f"
+            ;;
+    esac
+    zle reset-prompt
+}
+zle -N zle-line-init
+zle -N zle-line-finish
+zle -N zle-keymap-select
+
+# 直前のコマンドの成否で ❯ の色を変える関数
+function get_return_status() {
+    # %(?.正常時の色.エラー時の色)
+    echo "%(?.%F{green}❯%f.%F{red}❯%f)"
+}
+
+# precmdでは元のGit情報取得とタイマー処理を継続
+function precmd() {
+    vcs_info
+    if [ "$timer" ]; then
+        local duration=$(($SECONDS - $timer))
+        if [ $duration -ge 5 ]; then
+            PROMPT_DURATION="%F{yellow}⌛ ${duration}s%f "
+        else
+            PROMPT_DURATION=""
+        fi
+        unset timer
+    fi
+}
+
+# ==============================================================================
+# プロンプトの組み立て
+# ==============================================================================
+# ${VIM_MODE_ICON}（モードで切替）と $(get_return_status)（エラーで切替）を分離
+PROMPT='
+$(get_time)$(get_dir) $(get_git_info)$(get_env_info)${PROMPT_DURATION}
+${VIM_MODE_ICON} $(get_return_status) '
+
+# 複数行入力時のプロンプト
+PS2='%F{green}▶▶ %f'

--- a/extras/zsh-standalone-prompt/prompt.sh
+++ b/extras/zsh-standalone-prompt/prompt.sh
@@ -9,6 +9,16 @@ setopt prompt_subst
 bindkey -v
 # Escを押したときの反応速度を爆速にする（ミリ秒指定）
 export KEYTIMEOUT=1
+# Viモードでも使い慣れたEmacs風キーをinsertモードに残す（操作性維持）
+bindkey -M viins '^A' beginning-of-line
+bindkey -M viins '^E' end-of-line
+bindkey -M viins '^K' kill-line
+bindkey -M viins '^U' backward-kill-line
+bindkey -M viins '^W' backward-kill-word
+bindkey -M viins '^Y' yank
+bindkey -M viins '^?' backward-delete-char
+bindkey -M viins '^H' backward-delete-char
+# C-r は標準の履歴検索（mcfly等があればそちら）に委譲する
 
 # 1. 時刻 (淡いグレー)
 function get_time() {


### PR DESCRIPTION
## 概要

starship が使えない環境向けの zsh 標準機能プロンプトをリポジトリに保存し、あわせて通常設定(`dot_zshrc`)にも vim モードを導入する。

## 変更内容

### 1. standalone プロンプトの保存（chezmoi 管轄外）

- `extras/zsh-standalone-prompt/prompt.sh` — starship 無し環境向けの zsh 標準機能プロンプト
- `extras/zsh-standalone-prompt/README.md` — 用途・前提・starship 版との表示比較表・使い方
- `.chezmoiignore` に `extras/` を追加し `chezmoi apply` 対象外に
- `extras/.editorconfig`（`ignore = true`）で shfmt/shellcheck の対象から除外
  - ※ `prompt.sh` は zsh 固有のネストしたパラメータ展開を含み、shfmt が bash としてパースに失敗し CI が落ちるため

### 2. 通常設定(`dot_zshrc`)への vim モード導入

- `bindkey -v` + `KEYTIMEOUT=10` を早期に有効化（mcfly/WSL の bindkey が viins に束縛されるよう順序を担保）
  - `KEYTIMEOUT` は SSH 等の高遅延環境で ESC 始まりシーケンス（矢印/Ctrl-矢印等）が化けないよう 10(=100ms)に
- insert モードに Emacs 風キー（C-a/C-e 等）を残し操作性を維持
- mcfly 不在時の C-r 履歴検索フォールバックを追加（mcfly があれば後段で上書き優先）
- vim モード切替時に `zle reset-prompt` でプロンプト再描画
- カーソル形状を切替（normal=ブロック / insert=ビーム）
- `starship.toml` の `character` に `vicmd_symbol` 等を設定しモードインジケータを表示

### 3. プロンプトフックの追加型化

- `prompt.sh` の `precmd`/`preexec` を上書き型から `add-zsh-hook` 追加型に変更し、既存フックを潰さないように

## 確認

- `shfmt -i 2 -ci -w .` … 通過（extras は editorconfig で除外）
- `markdownlint-cli2` … 0 件

https://claude.ai/code/session_01Hs2ZSeuMfXP2rBB2yW4J26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hs2ZSeuMfXP2rBB2yW4J26)_