### PR TITLE
fix(zsh): 両プロンプトのVimグリフ(U+E7C5)欠落を修正し両モードにアイコン表示

### DIFF
--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -14,10 +14,10 @@ format = '[\[$symbol($subscription)\]]($style) '
 
 [character]
 # Vi モードのインジケータ（dot_zshrc の bindkey -v と連動）
-# insert/成否は ❯ の色で、normal モードは赤の Vim ロゴで表示
-success_symbol = '[❯](green)'
-error_symbol = '[❯](red)'
-vicmd_symbol = '[](red)'
+# insert=ペン 󰏫 +❯（成否で色）、normal=Vim ロゴ +❯（赤）。単体版と同じ見た目
+success_symbol = '[󰏫](green) [❯](green)'
+error_symbol = '[󰏫](green) [❯](red)'
+vicmd_symbol = '[](red) [❯](red)'
 
 [cmd_duration]
 min_time = 5_000  # Show command duration over 5,000 milliseconds (=5 sec)

--- a/extras/zsh-standalone-prompt/README.md
+++ b/extras/zsh-standalone-prompt/README.md
@@ -48,7 +48,7 @@ starship 未インストール環境では `dot_zshrc` の starship 初期化が
 | メモリ使用率 | `memory_usage` で表示 | ✗ 省略 |
 | 言語ランタイム等 | 各モジュールが自動表示 | ✗ 省略 |
 | 実行時間 | 5秒以上を `⌛` 表示 | 同左 |
-| Vi モード | `character` の vicmd_symbol +カーソル形状 | 専用アイコン（insert 󰏫 / normal ）+カーソル形状 |
+| Vi モード | insert=ペン 󰏫 +❯ / normal=Vim  +❯（character モジュール）+カーソル形状 | [アイコン] ❯ を自前で組み立て（見た目はほぼ同じ）+カーソル形状 |
 | 終了ステータス | `❯` の色で成否 | `❯` の色で成否（モードアイコンと分離表示） |
 | C-a/C-e 等 | dot_zshrc 側で insert に付与 | prompt.sh 内で insert に付与 |
 

--- a/extras/zsh-standalone-prompt/prompt.sh
+++ b/extras/zsh-standalone-prompt/prompt.sh
@@ -90,7 +90,7 @@ function zle-line-init zle-line-finish zle-keymap-select {
     case $KEYMAP in
         vicmd)
             # ノーマルモード時：赤のVimロゴ＋ブロックカーソル
-            VIM_MODE_ICON="%F{red}%f"
+            VIM_MODE_ICON="%F{red}%f"
             print -n '\e[2 q'
             ;;
         *)


### PR DESCRIPTION
## 概要

単体版・starship版の両プロンプトで **Vim ロゴ(U+E7C5)が欠落**し、normal モードでアイコンが表示されない不具合を修正する。あわせて starship 版のモード表示を単体版と揃える。

## 原因

初回のファイル作成時に、normal モード用の **Vim ロゴ(U+E7C5)が両ファイルから欠落**していた:

- `extras/zsh-standalone-prompt/prompt.sh` … `VIM_MODE_ICON="%F{red}%f"`（中身が空）
- `dot_config/starship.toml` … `vicmd_symbol = '[](red)'`（角カッコ内が空）

このため normal モードでアイコンが何も表示されず、`❯` が消える / 幅0でカーソル位置がずれる、という症状が出ていた。ペン `󰏫`(U+F03EB) は残っていたため「ペンは出るが Vim は出ない」状態だった。

## 修正

元プロンプトの **U+E7C5**(Devicons の Vim ロゴ ``)を両ファイルに復元。

### 単体版 (`prompt.sh`)

- insert = 緑のペン `󰏫` + ビームカーソル
- normal = 赤の Vim ロゴ `` + ブロックカーソル

### starship 版 (`dot_config/starship.toml` の `character`)

単体版と見た目を揃えるため、モードアイコン + `❯` の構成に:

- insert(成功) = `󰏫 ❯`（ペン緑 + ❯緑）
- insert(失敗) = `󰏫 ❯`（ペン緑 + ❯赤）
- normal = ` ❯`（Vim赤 + ❯赤）

カーソル形状切替（`dot_zshrc`、normal=ブロック / insert=ビーム）と合わせてモード判別が明確になる。

## 確認

- `markdownlint-cli2` … 0 件
- `starship.toml` … TOML パース OK
- `shfmt` … `extras/` は editorconfig で対象外

> 補足: 同じ欠落は main にも存在するため、本 PR はその修正にあたる。

https://claude.ai/code/session_01Hs2ZSeuMfXP2rBB2yW4J26