### PR TITLE
chore(claude): TUI をフルスクリーン化し advisor モデルを opus に固定

### DIFF
--- a/dot_claude/settings.json.src
+++ b/dot_claude/settings.json.src
@@ -126,5 +126,7 @@
   "enabledPlugins": {},
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",
-  "teammateMode": "tmux"
+  "tui": "fullscreen",
+  "teammateMode": "tmux",
+  "advisorModel": "opus"
 }


### PR DESCRIPTION
## 概要

`dot_claude/settings.json.src` にキーを2つ追加する。

| キー | 値 | 目的 |
| --- | --- | --- |
| `tui` | `"fullscreen"` | Claude Code を全画面 TUI で起動する |
| `advisorModel` | `"opus"` | advisor ツールが参照するモデルを明示固定する |

## 検証

JSON Schema 検証をローカルで実行し通過を確認済み（CI の `json-schema-validate.yaml` と同一条件）。

```bash
uvx check-jsonschema==0.37.0 \
  --schemafile "https://json.schemastore.org/claude-code-settings.json" \
  dot_claude/settings.json.src
# → ok -- validation done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)