### PR TITLE
feat(nix): herdr（ターミナル用エージェント多重化ツール）を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ git config user.signingkey "$(ssh-add -L | grep 'SOME_CONDITION')"
   - <https://github.com/joaojacome/bitwarden-ssh-agent> の`6237a3604`を利用
   - 使用する場合、利用者各個人で内容確認推奨
 - [Nix](https://nixos.org/) による開発ツール管理
-  - CLIツール・開発コマンドを`flake.nix`で統合管理（約30パッケージ）
+  - CLIツール・開発コマンドを`flake.nix`で統合管理（約40パッケージ）
   - 主要ツール: git, fzf, ripgrep, fd, bat, starship, delta, lsd, mcfly, zoxide, xh, uv, bun, prek, actionlint など
+  - TUIツール: zellij, herdr（エージェント多重化）, oxker, ov, glow
   - 全パッケージ一覧は[flake.nix](flake.nix)を参照
   - システム環境の再現性を向上
   - パッケージ追加後の更新: `nix profile upgrade .` または `nix profile add .`

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,7 @@
             ov                # Feature-rich terminal pager
             glow              # Terminal Markdown renderer
             zellij            # Terminal workspace / multiplexer
+            herdr             # Agent multiplexer for the terminal
 
             # Editors
             neovim            # Hyperextensible Vim-based editor


### PR DESCRIPTION
## 概要

`flake.nix` の TUI ツール群に [herdr](https://herdr.dev) を追加する。

| 項目 | 値 |
| --- | --- |
| nixpkgs attribute | `herdr` |
| バージョン | 0.8.0 |
| 説明 | Agent multiplexer that lives in your terminal |
| homepage | <https://herdr.dev> |

あわせて README のパッケージ数表記（約30 → 約40）を実態に合わせ、TUI ツール行を追加した。

## 検証

```bash
nix build .#default --no-link --print-out-paths
# → /nix/store/ilxcjmydj4grhd0da8d9ch0xmpqzmbjp-user-cli-tools

/nix/store/ilxcjmydj4grhd0da8d9ch0xmpqzmbjp-user-cli-tools/bin/herdr --version
# → herdr 0.8.0
```

- `markdownlint-cli2 README.md` → 0 issues

## 備考

`flake.lock` は `.gitignore` により追跡対象外のため、本 PR に lock の差分は含まれない。
検証は nixpkgs `0e251e24`（2026-08-13）で実施している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)