### PR TITLE
fix(chezmoi): .chezmoiignore の `/*.md` を `*.md` に修正し E2E 失敗を解消

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -6,7 +6,10 @@
 # Documentation files - ドキュメントファイル
 # ルート直下の .md のみ除外（dot_claude/ 配下の SKILL.md や
 # rules/*.md はホームへ展開する必要があるため除外しない）
-/*.md
+# `*` は `/` を跨がないため、スラッシュを含まないこのパターンはルート直下のみに
+# マッチする。先頭 `/` 付き（`/*.md`）は chezmoi 2.72.0 以降の Linux で
+# "invalid path" として拒否されるため使用しない。
+*.md
 
 # Superpowers docs - 設計ドキュメント
 docs/


### PR DESCRIPTION
## 問題

`E2E Test - Ubuntu` が `chezmoi apply` の起動直後に失敗する。

```text
chezmoi: /home/runner/.local/share/chezmoi/.chezmoiignore:9: /*.md: invalid path
```

chezmoi 2.72.0 の Linux ビルドは先頭 `/` 付きの `.chezmoiignore` パターンを
`invalid path` として拒否するようになった。

**これは既存の破損であり、#193 / #194 の変更内容には起因しない。**
CI は `get.chezmoi.io` から常に最新版を取得するため、main の最終成功
（2026-06-03, chezmoi はそれ以前のバージョン）以降に chezmoi 側の変更で
顕在化した。`Windows Dotfiles Setup`（winget, 同じ 2.72.0）は同パターンを
受け付けるため pass しており、Linux 側のみ失敗していた。

## 修正

`/*.md` → `*.md`

`*` は `/` を跨がないため、スラッシュを含まない `*.md` はルート直下のみに
マッチする。元の意図（ルート直下の `.md` のみ除外し、`dot_claude/` 配下の
`CLAUDE.md` や `commands/**/*.md` は展開する）はそのまま保たれる。

## 検証

すべてローカルで実施（CI 版 2.72.0 のバイナリを取得して実行）。

**1. 挙動が完全に保存されていること**

| chezmoi | パターン | `chezmoi managed` |
| --- | --- | --- |
| 2.62.6 | `/*.md`（修正前） | 61 エントリ（ベースライン） |
| 2.72.0 | `*.md`（修正後） | 61 エントリ、**diff なし** |
| 2.62.6 | `*.md`（修正後） | 61 エントリ、**diff なし** |

**2. CI 同等の apply が成功すること**（chezmoi 2.72.0）

```bash
chezmoi apply --exclude scripts --force   # → 成功
```

E2E が検証する 7 ファイル（`.bashrc` `.bash_profile` `.profile` `.gitconfig`
`.vimrc` `.zshrc` `.zshenv`）すべて展開を確認。

**3. 除外範囲が意図どおりであること**

展開後に存在する `.md` は以下 3 件のみで、ルート直下の `.md`
（`README.md` `CLAUDE.md` `FZF_UTILS.md` `MIGRATION.md`）の流出はなし。

```text
~/.claude/CLAUDE.md
~/.claude/commands/chezmoi/verify-sync.md
~/.claude/commands/lint/all.md
```

## マージ順序

この PR を最初にマージすると #193 / #194 の E2E も解消する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)