### PR TITLE
feat(nix): flake.lock を追跡し週次の自動更新PRワークフローを追加

### DIFF
--- a/.github/workflows/flake-lock-update.yaml
+++ b/.github/workflows/flake-lock-update.yaml
@@ -92,8 +92,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" || true
-          git push origin "$BRANCH" --force-with-lease
+          # 追跡ブランチが無い状態で --force-with-lease を使うと fatal になるため、
+          # リモートに既存ブランチがある場合のみ lease を付ける
+          if git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"; then
+            git push origin "$BRANCH" --force-with-lease
+          else
+            git push origin "$BRANCH"
+          fi
 
           if [ "$BUILD_OUTCOME" = "success" ]; then
             BUILD_LINE="✅ \`nix build .#default\` 成功"

--- a/.github/workflows/flake-lock-update.yaml
+++ b/.github/workflows/flake-lock-update.yaml
@@ -1,0 +1,151 @@
+---
+name: flake.lock update
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # 毎週月曜 09:00 UTC (JST 18:00)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: flake-lock-update
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update flake.lock and verify build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Update flake.lock
+        id: update
+        run: |
+          set -euo pipefail
+
+          # flake.lock の各 input の固定リビジョンを 1 行 1 input で書き出す
+          lock_summary() {
+            jq -r '
+              .nodes
+              | to_entries[]
+              | select(.value.locked != null)
+              | "\(.key) \(.value.locked.rev // .value.locked.narHash)"
+            ' "$1" | sort
+          }
+
+          lock_summary flake.lock > /tmp/lock-before.txt
+          nix flake update
+
+          if git diff --quiet -- flake.lock; then
+            echo "flake.lock はすでに最新のため更新なし"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          lock_summary flake.lock > /tmp/lock-after.txt
+
+          NIXPKGS_REV=$(jq -r '.nodes.nixpkgs.locked.rev' flake.lock)
+          {
+            echo "changed=true"
+            echo "nixpkgs_rev=$NIXPKGS_REV"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Commit to update branch
+        id: commit
+        if: steps.update.outputs.changed == 'true'
+        env:
+          NIXPKGS_REV: ${{ steps.update.outputs.nixpkgs_rev }}
+        run: |
+          set -euo pipefail
+
+          BRANCH="nix/flake-lock-update"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add flake.lock
+          git commit -m "chore(nix): flake.lock を更新 (nixpkgs ${NIXPKGS_REV:0:12})"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      # GITHUB_TOKEN が作成した PR では workflow がトリガーされないため、
+      # 再現性の検証はこのワークフロー内で実施し結果を PR 本文に残す
+      - name: Verify build
+        id: build
+        if: steps.update.outputs.changed == 'true'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          nix build .#default --no-link --print-out-paths
+
+      - name: Create or update pull request
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          NIXPKGS_REV: ${{ steps.update.outputs.nixpkgs_rev }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          set -euo pipefail
+
+          git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" || true
+          git push origin "$BRANCH" --force-with-lease
+
+          if [ "$BUILD_OUTCOME" = "success" ]; then
+            BUILD_LINE="✅ \`nix build .#default\` 成功"
+          else
+            BUILD_LINE="❌ \`nix build .#default\` 失敗 — **マージしないこと**"
+          fi
+
+          {
+            echo "## flake.lock 週次更新"
+            echo
+            echo "- nixpkgs: \`${NIXPKGS_REV}\`"
+            echo "- 再現性チェック: ${BUILD_LINE}"
+            echo "- 実行ログ: ${RUN_URL}"
+            echo
+            echo "### 固定リビジョンの変化"
+            echo
+            echo '```diff'
+            diff -u /tmp/lock-before.txt /tmp/lock-after.txt || true
+            echo '```'
+            echo
+            echo "### 補足"
+            echo
+            echo "\`GITHUB_TOKEN\` で作成した PR は workflow をトリガーしないため、"
+            echo "この PR には CI チェックが付かない。再現性チェックは上記の実行ログ内で"
+            echo "実施済み。E2E などを走らせたい場合は \`gh pr update-branch\` などで"
+            echo "コミットを積み直すか、ローカルで確認する。"
+            echo
+            echo "### ローカルでの確認手順"
+            echo
+            echo '```bash'
+            echo "git fetch origin ${BRANCH} && git switch ${BRANCH}"
+            echo "nix build .#default --no-link --print-out-paths"
+            echo '```'
+          } > /tmp/pr-body.md
+
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""')
+
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --body-file /tmp/pr-body.md
+            gh pr comment "$EXISTING" --body "flake.lock を再更新した (nixpkgs \`${NIXPKGS_REV:0:12}\`, 再現性チェック: ${BUILD_OUTCOME})。"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(nix): flake.lock を更新 (nixpkgs ${NIXPKGS_REV:0:12})" \
+              --body-file /tmp/pr-body.md \
+              --label "dependencies" \
+              --label "automated"
+          fi
+
+      - name: Fail if reproducibility check failed
+        if: steps.update.outputs.changed == 'true' && steps.build.outcome == 'failure'
+        run: |
+          echo "::error::flake.lock 更新後の nix build が失敗した。PR はマージせず調査すること。"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -215,4 +215,5 @@ megalinter-reports/
 .worktrees/
 
 # Nix
-flake.lock
+# flake.lock はバージョン管理下に置く（マシン間で nixpkgs リビジョンを固定し
+# 再現性を確保するため）。ホームへは展開しないので .chezmoiignore 側で除外する。

--- a/README.md
+++ b/README.md
@@ -104,8 +104,10 @@ git config user.signingkey "$(ssh-add -L | grep 'SOME_CONDITION')"
   - 主要ツール: git, fzf, ripgrep, fd, bat, starship, delta, lsd, mcfly, zoxide, xh, uv, bun, prek, actionlint など
   - TUIツール: zellij, herdr（エージェント多重化）, oxker, ov, glow
   - 全パッケージ一覧は[flake.nix](flake.nix)を参照
-  - システム環境の再現性を向上
-  - パッケージ追加後の更新: `nix profile upgrade .` または `nix profile add .`
+  - `flake.lock`をバージョン管理下に置き、マシン間でnixpkgsリビジョンを固定する
+  - パッケージ追加後の更新: `nix profile upgrade --all`（nix 2.32以降。`nix profile upgrade .`は非対応）
+  - ツールのバージョン更新: `git pull`で`flake.lock`を取得してから`nix profile upgrade --all`
+  - `flake.lock`自体の更新は週次のGitHub Actionsが自動PR化する（後述）
 - [Starship](https://starship.rs/ja-jp/)
 - [mise (alt asdf)](https://github.com/jdx/mise)（言語ランタイム管理: Node.js、Python）
 - [uv](https://docs.astral.sh/uv/)（Pythonパッケージ管理・uvxによるツール実行）
@@ -311,6 +313,38 @@ allowed-tools: Edit, Bash(npm:*)
 フォルダ内の Markdown ファイルは更新時にmarkdownlint-cli2によってチェックされている。
 
 NOTE: markdownlintによるチェックとの違いは要検証
+
+## 定期アップデート
+
+### flake.lock（Nix管理ツール）
+
+`.github/workflows/flake-lock-update.yaml`が毎週月曜09:00 UTC（JST 18:00）に実行される。
+
+| ステップ | 内容 |
+| --- | --- |
+| 更新 | `nix flake update`を実行し、差分がなければ何もせず終了 |
+| コミット | `nix/flake-lock-update`ブランチに`flake.lock`をコミット |
+| 再現性チェック | `nix build .#default`でビルド可否を検証 |
+| PR | PRを作成（既存PRがあれば本文を更新してコメント追加） |
+
+`GITHUB_TOKEN`が作成したPRはworkflowをトリガーしないため、この自動PRにはCIチェックが付かない。
+そのため再現性チェックはワークフロー内で実施し、結果をPR本文に記載している。
+ビルドが失敗した場合はワークフロー自体がfailするため、Actionsタブと通知で気付ける。
+
+手動実行は`workflow_dispatch`（ActionsタブのRun workflow）から可能。
+
+### mise管理ツール（言語ランタイム）
+
+mise設定（`~/.config/mise/config.toml`）はマシンローカルでリポジトリ管理外のため、
+CIによる自動化対象ではない。手動で更新する。
+
+```bash
+mise upgrade
+```
+
+NOTE: Node.jsの更新にはリリース署名鍵の検証が必要。
+`gpg: Can't check signature: No public key`で失敗する場合は
+[nodejs/release-keys](https://github.com/nodejs/release-keys)から該当鍵をimportする。
 
 ## その他
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
## 背景

`flake.lock` は `.gitignore` で除外されていた（2025-11-22 の cb3e4bc で
「not needed in version control」として追加。設計上の根拠はコミット・docs・README
のいずれにも記録なし）。結果として各マシンが `nix profile upgrade` 時点の
nixos-unstable を拾う浮動運用になっており、README が謳う「システム環境の再現性」は
実際には成立していなかった。

また、リポジトリには `schedule:` / `cron` を持つワークフローが1つも無く、
定期アップデートの仕組みは存在しない（唯一の自動更新だった `rtk-update-check.yml` は
b3cb6af の rtk 撤去で削除済み）。

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `.gitignore` | `flake.lock` の除外を削除 |
| `flake.lock` | nixpkgs `0e251e24`（2026-08-13）を初回コミット |
| `.github/workflows/flake-lock-update.yaml` | 週次の自動更新PRワークフローを新規追加 |
| `README.md` | 運用変更と「定期アップデート」節を追記 |

`.chezmoiignore` 側の `flake.lock` 除外は**維持する**。あちらはホームディレクトリへ
展開しないための指定であり、正しい。

### 運用の変化

これがこの PR で得られるものの本体。

| | 変更前 | 変更後 |
| --- | --- | --- |
| nixpkgs リビジョン | マシンごとに apply 時点の最新（浮動） | `flake.lock` で固定 |
| ツール更新手順 | `nix profile upgrade` で暗黙に最新化 | `git pull` → `nix profile upgrade --all` |
| lock の更新 | 手動・記録なし | 週次PRでレビューしてマージ |

あわせて README の `nix profile upgrade .` を `--all` に修正した。
nix 2.32 では `.` はエレメント名として解釈されずマッチしない。

### ワークフローの設計

毎週月曜 09:00 UTC（JST 18:00）+ `workflow_dispatch`。

1. `nix flake update` — 差分がなければ何もせず終了
2. `nix/flake-lock-update` ブランチに `flake.lock` をコミット
3. `nix build .#default` で再現性チェック（`continue-on-error`）
4. PR 作成（既存の open PR があれば本文更新＋コメント追加）
5. ビルドが失敗していた場合は最後にジョブを fail させる

**`GITHUB_TOKEN` が作成した PR は workflow をトリガーしない**ため、この自動 PR には
E2E や linter のチェックが付かない。そこで再現性チェックをワークフロー内で実施し、
結果（✅ / ❌）を PR 本文に埋め込む設計にした。ビルド失敗時はジョブ自体が fail するので
Actions タブと scheduled-workflow-failure 通知で気付ける。

撤去済みの rtk ワークフローから流用したのは cron スケジュールと再現性チェックの
ジョブ構造のみ。manifest の sha256 更新・フック取得・サプライチェーン lint・
cooldown といった rtk 固有の機構は持ち込んでいない。
`magic-nix-cache-action` も使っていない（週1回の単発ビルドにキャッシュは不要で、
`@main` 参照の第三者 action を1つ減らせる）。`nix-installer-action` はタグ `v22` で固定。

## 検証

```bash
actionlint .github/workflows/flake-lock-update.yaml   # → exit 0
nix build .#default --no-link --print-out-paths       # → 成功
git check-ignore -v flake.lock                        # → 非除外（exit 1）
markdownlint-cli2 README.md                           # → 0 issues
```

## マージ順序

README の隣接行を #194 が編集しているため、**#195 → #194 → 本PR** の順にマージし、
本PRは #194 の後に rebase するとコンフリクトを避けられる。

## 本PRに含まれないもの

mise 側の定期更新の CI 化。mise 設定は `~/.config/mise/config.toml` にのみ存在し
リポジトリ管理外のため、CI から PR を出す対象が無い。README には手動更新手順
（`mise upgrade`）と、Node.js のリリース署名鍵に関する注意を記載した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)