### PR TITLE
feat(claude): CLAUDE.md を Opus 5 向けに更新し rules/ は作らず統合

### DIFF
--- a/.chezmoiremove
+++ b/.chezmoiremove
@@ -1,0 +1,10 @@
+# chezmoi はソース側のエントリを削除してもターゲットを消さないため、
+# 撤去済みファイルがホームに残り続ける。ここに列挙すると apply 時に削除される。
+#
+# 全マシンで apply が一巡したら、該当行は削除してよい。
+
+# rtk 統合の撤去 (#192) で不要になったルール
+.claude/rules/rtk.md
+
+# delegation.md は CLAUDE.md の "Delegation and effort" 節へ統合した
+.claude/rules/delegation.md

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -16,3 +16,35 @@ This file contains Claude Code standards applied across all projects.
 ## Communication
 
 - Think and reason in English, but respond to the user in Japanese
+- Keep responses focused and concise. Keep caveats short and spend most of the
+  response on the main answer. When asked to explain something, give a
+  high-level summary unless an in-depth explanation is requested
+- Effort settings control how much the model thinks, not how much it says.
+  Response length has to be asked for explicitly
+
+## Progress updates during work
+
+- Before the first tool call, say in one sentence what you are about to do
+- While working, give a brief update only when you find something important or
+  change direction
+- When finished, lead with the outcome: the first sentence should answer "what
+  happened" or "what did you find", with supporting detail after it
+
+## Written deliverables
+
+Files written to disk (documents, reports, summaries) run long by default.
+
+- Match the length of a written document to what the task needs: cover the
+  substance, but do not pad with filler sections, redundant summaries, or
+  boilerplate
+- This applies to this repository's own docs: README sections, `docs/` design
+  documents, and handover notes
+
+## Delegation and effort
+
+- Delegate to a subagent only for large, genuinely independent work such as a
+  wide multi-file investigation. Do not delegate what you can finish in a
+  handful of tool calls, and do not use subagents to verify your own work
+  (the `claude-code-guide` case above is the intended exception)
+- Use `low`/`medium` effort as the primary lever for cost and latency wherever
+  quality holds. Step up to `xhigh` only for demanding coding and agentic work


### PR DESCRIPTION
## 方針変更

当初は `~/.claude/rules/` を chezmoi 管理下へ戻す PR だった。rules 機構を公式
ドキュメントで確認した結果、**分割せず `CLAUDE.md` 一本に畳む**方針へ変更した。

### 確認結果

出典: <https://code.claude.com/docs/en/memory.md>

| 項目 | 結果 |
| --- | --- |
| `~/.claude/rules/` は公式機構か | user / project 両方でサポート |
| frontmatter なしのルール | **無条件ロード**、優先度は `CLAUDE.md` と同じ |
| 条件付きロード | `paths:` フロントマター（YAML リスト） |
| **user scope で `paths:` が機能するか** | **ドキュメントに記載なし** |
| 読み込み順 | user → project（project が高優先） |

`paths:` の user scope 動作は公式に保証されていない（非公式には動作しないという
報告が複数あるが、内容が相互に矛盾しており信頼できない）。確実に知るには
`InstructionsLoaded` フックで `path_glob_match` の発火を観測するのが唯一の
裏付けある手段。

### 畳む理由

1. frontmatter なしなら無条件ロードなので、分割はトークンを払うだけで得がない
2. 条件付きロードは user scope で保証されていないため、構成を賭けられない
3. chezmoi はソース削除時にターゲットを消さないため、ファイルを増やすほど
   孤児化の failure mode が増える。本セッションで `rtk.md` と `delegation.md` の
   2件を実際に踏んだ

3ファイル目以降が出てきた時点で、`InstructionsLoaded` で挙動を確認してから
分割を検討すればよい。

## CLAUDE.md への追加

[Prompting Claude Opus 5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5)
のうち、**Claude Code 側が注入していない項目のみ**に絞った。

| 追加した節 | 理由 |
| --- | --- |
| 応答の簡潔さ | Opus 5 の既定応答は長い。effort は思考量を制御するが発話量は制御しないため明示が必要 |
| 作業中の進捗報告 | 最初のツール呼び出し前に一文、途中は重要な発見か方針転換時のみ、最後は結論から |
| ディスク上の成果物の長さ | 書き出すドキュメントが冗長になりやすい。README や `docs/` を生成するこのリポジトリでは実害が出る |
| 委譲の判断と effort | `low`/`medium` を主要レバー、`xhigh` は高難度のみ |

タスクスコープと自己訂正の指針は既にシステムプロンプトへ注入されているため
重複させていない。Claude Code の更新で内容がずれた際に矛盾するのを避ける。

## 旧 delegation.md から落としたもの

`~/.claude/rules/delegation.md` は b3cb6af (#192) で既にリポジトリから削除済みで、
ホームに残っていたのは chezmoi の挙動による孤児。内容も Opus 5 の指針と衝突していた。

| 落とした内容 | 理由 |
| --- | --- |
| Never implement directly / Always delegate | 数回のツール呼び出しで終わる作業の委譲はコストと時間だけ増やす |
| 曖昧さが解消するまで AskUserQuestion を繰り返す | 解釈の違いが成果物を実質的に変える場合のみ確認する |
| Verification checklist | 明示的な検証指示は over-verification を招く |
| fork 判定・モデル選択表 | `context: fork` / `agent:` の実在を確認できておらず、対象の SKILL.md は別リポジトリ [ebal5/agent-skills](https://github.com/ebal5/agent-skills) にある |

## `.chezmoiremove` の追加

孤児化の再発を塞ぐ。撤去済みの `rtk.md` と `delegation.md` を apply 時に
ホームから削除する。全マシンで apply が一巡したら該当行は削除してよい。

ディレクトリごとではなく既知の2ファイルのみを列挙している。`.claude/rules/` を
まとめて指定すると、後から手動で置いたファイルまで消してしまうため。

## 検証

```bash
markdownlint-cli2 dot_claude/CLAUDE.md README.md   # → 0 issues

# 隔離先に孤児2件を置いて apply → 両方削除されることを確認
chezmoi apply --destination <隔離先> --exclude scripts --force
```

実ホームへも apply 済みで、`~/.claude/rules/` は空。

🤖 Generated with [Claude Code](https://claude.com/claude-code)