### PR TITLE
docs(readme): スキルの節を実態に合わせ、一覧の複製をやめる

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,24 +237,22 @@ git config user.signingkey "$(ssh-add -L | grep 'SOME_CONDITION')"
 | context7 | ライブラリドキュメント検索 |
 | serena | IDEアシスタント機能 |
 
-### スキルジェネレーター
+### エージェントスキル
 
-[Anthropic公式のスキルジェネレータープラグイン](https://github.com/anthropics/skills)が有効化されています。
+スキルはプラグインではなく、`run_once_after_install_agent_skills.sh.tmpl`が
+`gh skill install`でユーザースコープ（`~/.claude/skills/`）へ導入する。
+供給元は2つで、いずれもバージョンをピン留めしている。
 
-#### 使い方
+| 供給元 | ピン | 導入するスキル |
+| --- | --- | --- |
+| [ebal5/agent-skills](https://github.com/ebal5/agent-skills) | タグ（`OWN_PIN`） | `install-sets/common.txt`の記載に従う |
+| [anthropics/skills](https://github.com/anthropics/skills) | コミットSHA（`UPSTREAM_PIN`） | `skill-creator`, `mcp-builder`, `pdf`, `doc-coauthoring` |
 
-1. Claude Codeで「〇〇のスキルを作成して」と依頼
-2. スキルジェネレーターが自動的にスキルファイルを生成
-3. 生成されたスキルは`.claude/skills/`に保存される
+自作スキルの一覧はピン先の`install-sets/common.txt`が唯一の情報源で、
+このREADMEには複製しない。ピンを上げるとスクリプトの内容ハッシュが変わり、
+次回の`chezmoi apply`で再実行されて新しい一覧が反映される。
 
-#### 同梱スキル
-
-| スキル | 説明 |
-| --- | --- |
-| `grill-me` | プランや設計を徹底的にヒアリング |
-| `handover` | セッション終了時の引き継ぎドキュメント作成 |
-| `markdown-check` | Markdownドキュメントの整合性・リンク切れ検証 |
-| `uv-script` | uvシバン付きスタンドアロンPythonスクリプト作成 |
+`enabledPlugins`は空であり、プラグイン経由でスキルを導入してはいない。
 
 #### スキルとは
 


### PR DESCRIPTION
## 修正した誤り

| README の記述 | 実態 |
| --- | --- |
| 「Anthropic公式のスキルジェネレータープラグインが有効化されています」 | `enabledPlugins` は #192 以降**空**。プラグインは使っていない |
| 同梱スキル4件（`grill-me` / `handover` / `markdown-check` / `uv-script`） | ピン先の `install-sets/common.txt` には**7件** |
| （記載なし） | 実際は `run_once_after_install_agent_skills.sh.tmpl` が `gh skill install` でユーザースコープへ導入 |

## 一覧を再掲するのをやめた

同じズレが再発するため、スキル一覧の複製を削除して供給元とピンの仕組みだけを記述した。

| 供給元 | ピン | このREADMEでの扱い |
| --- | --- | --- |
| `ebal5/agent-skills` | タグ（`OWN_PIN`） | `install-sets/common.txt` を唯一の情報源として参照 |
| `anthropics/skills` | コミットSHA（`UPSTREAM_PIN`） | 4件をこのリポジトリのスクリプトにハードコードしているため記載 |

README が既にパッケージ一覧（「全パッケージ一覧は flake.nix を参照」）や
エイリアス一覧（「全一覧は dot_gitconfig を参照」）で使っている
「ポインタ＋抜粋」パターンに揃えた。

## 併せて確認した範囲

ズレていたのはこの節だけだった。

| README の表 | 突き合わせ先 | 結果 |
| --- | --- | --- |
| カスタムスラッシュコマンド | `dot_claude/commands/**`（2件） | 一致 |
| グローバルMCPサーバー | `dot_mcp.json.src` の keys（2件） | 一致 |
| 含まれる設定 | `dot_claude/` 直下 | 一致 |

## 検証

```bash
markdownlint-cli2 README.md   # → 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)