### PR TITLE
chore(claude): agent-skills のピンを v0.3.0 へ更新

### DIFF
--- a/dot_claude/run_once_after_install_agent_skills.sh.tmpl
+++ b/dot_claude/run_once_after_install_agent_skills.sh.tmpl
@@ -10,7 +10,7 @@ set -euo pipefail
 # Skill list is fetched from install-sets/common.txt at the pinned ref so
 # agent-skills stays the single source of truth; bump OWN_PIN to refresh.
 OWN_REPO="ebal5/agent-skills"
-OWN_PIN="v0.2.1"
+OWN_PIN="v0.3.0"
 mapfile -t OWN_SKILLS < <(
   gh api "repos/${OWN_REPO}/contents/install-sets/common.txt?ref=${OWN_PIN}" \
     --jq '.content' | base64 -d \


### PR DESCRIPTION
## 変更

`run_once_after_install_agent_skills.sh.tmpl` の `OWN_PIN` を `v0.2.1` → `v0.3.0` に上げ、
[ebal5/agent-skills](https://github.com/ebal5/agent-skills) の v0.3.0（`fb8d423e`）へ追従する。

`OWN_PIN` を変えるとスクリプトの内容ハッシュが変わるため、次回の `chezmoi apply` で
`run_once` スクリプトが再実行され、新しい一覧が反映される。

## 配布対象の変化

| 区分 | スキル |
| --- | --- |
| 削除 | `dev-workflow`, `review-loop` |
| 改名 | `grill-me` → `grilling` |
| 追加 | `skill-audit`, `teach-me` |

`dev-workflow` は5フェーズ（grill → brainstorm → plan → execute → wrap-up）のうち
Phase 0 以外が `superpowers:*` と `/commit-commands:commit-push-pr` への委譲で構成されていたが、
これらは #192 で全て無効化済み（`enabledPlugins: {}`）のため機能していなかった。
それでいて `common.txt` の先頭にあり全マシンへ配布されていた。

`review-loop` は組み込みの `/code-review` と重複するため上流で削除された。

## 検証

```bash
git rev-parse v0.3.0^{commit}   # → fb8d423e97cf3340f90fec98868bef8fb6ff9982
git show v0.3.0:install-sets/common.txt   # → 7件、すべて skills/ に実在
rg -c 'dev-workflow' .          # → 参照ゼロ
```

`shfmt` の差分がこのファイルに出るが main と同一の既存差分であり、
`.tmpl` は `shfmt -f` の対象外のため CI の検査範囲にも入っていない。本PRでは触っていない。

## 既知の残課題（本PRの範囲外）

`gh skill install` はコピー配布で、**`gh skill` に `uninstall` サブコマンドが存在しない**
（`install` / `list` / `preview` / `publish` / `search` / `update` のみ）。
そのため配布対象から外れたスキルは `~/.claude/skills/` に残り続ける。

実際この環境には `dev-workflow` / `grill-me` / `review-loop` が残存している。
`.chezmoiremove` では拾えない（`~/.claude/skills/` は chezmoi 管理外）ため、
スクリプト側に prune を実装する必要がある。別途対応する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)