### PR TITLE
feat(claude): 配布対象から外れたエージェントスキルを prune する

### DIFF
--- a/dot_claude/run_once_after_install_agent_skills.sh.tmpl
+++ b/dot_claude/run_once_after_install_agent_skills.sh.tmpl
@@ -17,6 +17,14 @@ mapfile -t OWN_SKILLS < <(
     | awk '/^[[:space:]]*#/ || /^[[:space:]]*$/ {next} {print $1}'
 )
 
+# mapfile runs in a process substitution, so a failed fetch yields an empty
+# array instead of aborting. Bail out explicitly: an empty list would make the
+# prune step below delete every skill this script manages.
+if [ "${#OWN_SKILLS[@]}" -eq 0 ]; then
+  echo "[error] could not read install-sets/common.txt from ${OWN_REPO}@${OWN_PIN}" >&2
+  exit 1
+fi
+
 for skill in "${OWN_SKILLS[@]}"; do
   echo ">> gh skill install ${OWN_REPO} ${skill} --pin ${OWN_PIN}"
   gh skill install "${OWN_REPO}" "${skill}" \
@@ -32,6 +40,45 @@ for skill in "${UPSTREAM_SKILLS[@]}"; do
   echo ">> gh skill install ${UPSTREAM_REPO} ${skill} --pin ${UPSTREAM_PIN:0:8}"
   gh skill install "${UPSTREAM_REPO}" "${skill}" \
     --agent claude-code --scope user --pin "${UPSTREAM_PIN}" --force
+done
+
+# Remove skills this script installed earlier that are no longer declared.
+# `gh skill` has no uninstall subcommand and install is a plain copy, so a
+# skill dropped from the lists above would otherwise linger on every machine
+# forever. Only skills whose SKILL.md records one of our two source repos are
+# eligible, which leaves manually installed skills untouched.
+SKILLS_DIR="${HOME}/.claude/skills"
+DECLARED=("${OWN_SKILLS[@]}" "${UPSTREAM_SKILLS[@]}")
+
+is_declared() {
+  local candidate="$1" declared
+  for declared in "${DECLARED[@]}"; do
+    # common.txt accepts "category/skill-name"; installs land flat
+    [ "${candidate}" = "${declared##*/}" ] && return 0
+  done
+  return 1
+}
+
+for manifest in "${SKILLS_DIR}"/*/SKILL.md; do
+  [ -f "${manifest}" ] || continue
+  dir=$(dirname "${manifest}")
+  name=$(basename "${dir}")
+
+  # gh skill install records the source repo; a skill without it was put there
+  # by hand and is none of this script's business
+  grep -qE "^[[:space:]]*(origin|github-repo):.*(${OWN_REPO}|${UPSTREAM_REPO})" \
+    "${manifest}" || continue
+
+  # Pre-directory layout left a flat <name>.md next to the <name>/ directory
+  if [ -f "${SKILLS_DIR}/${name}.md" ]; then
+    echo ">> prune legacy ${name}.md"
+    rm -f "${SKILLS_DIR}/${name}.md"
+  fi
+
+  if ! is_declared "${name}"; then
+    echo ">> prune ${name} (no longer declared)"
+    rm -rf "${dir:?}"
+  fi
 done
 {{ else -}}
 #!/usr/bin/env bash


### PR DESCRIPTION
## 問題

`gh skill install` はコピー配布で、**`gh skill` に `uninstall` サブコマンドが存在しない**。

```console
$ gh skill --help
AVAILABLE COMMANDS
  install / list / preview / publish / search / update
```

そのため配布リストから外したスキルは全マシンの `~/.claude/skills/` に残り続ける。
実際にこの環境には `dev-workflow` / `grill-me` / `review-loop` が残存している
（いずれも上流 v0.3.0 で削除・改名済み）。

`~/.claude/skills/` は chezmoi 管理外（`dot_claude/skills/` は存在しない）なので
`.chezmoiremove` では拾えず、インストールスクリプト側で対処する必要がある。

これは今セッションで3度目の「宣言から消しても実体が残る」失敗で、
`rtk.md` / `delegation.md` は `.chezmoiremove` で塞いだが、こちらは別機構になる。

## 実装

インストール後に prune ステップを追加する。手動導入したスキルを巻き込まないよう、
**`SKILL.md` の `origin` / `github-repo` が自リポジトリか上流を指すものだけ**を対象にする。
`gh skill install` はこれらを注入するため、手動で置いたスキルには存在しない。

## 併せて入れた安全策

**1. `OWN_SKILLS` が空なら `exit 1`**

`mapfile` はプロセス置換の中で走るため、`gh api` の失敗が `set -e` で捕捉されない。
空リストのまま prune へ進むと**管理下の全スキルを削除**してしまう。これを明示的に止める。

**2. 旧フラット形式 `<name>.md` の削除**

ディレクトリ形式になる前の名残。現に `~/.claude/skills/uv-script.md`（2025-12-05）が
`uv-script/` と併存している。

## 検証

fixture を作り、prune ブロックを抽出して実データで実行した。

| fixture | 由来 | 宣言 | 期待 | 結果 |
| --- | --- | --- | --- | --- |
| `dev-workflow`, `review-loop` | `ebal5/agent-skills` | なし | 削除 | 削除 |
| `old-upstream` | `anthropics/skills` | なし | 削除 | 削除 |
| `dev-workflow.md`, `uv-script.md` | 旧形式 | — | 削除 | 削除 |
| `grilling`, `uv-script`, `pdf` | 両リポジトリ | あり | 保持 | 保持 |
| `cognitive-rhythm-writing`, `japanese-tech-writing` | **メタデータなし** | — | 保持 | 保持 |
| `vendored-elsewhere` | `mattpocock/skills` | なし | 保持 | 保持 |

最後の2行が重要で、**手動導入のスキルと、対象外リポジトリ由来の vendor は削除されない**。

空配列ガードが `exit 1` で発火することも個別に確認済み。

```console
$ OWN_SKILLS=(); [ "${#OWN_SKILLS[@]}" -eq 0 ] && ...
[error] could not read install-sets/common.txt from x@y
exit=1
```

## 補足

`common.txt` は `category/skill-name` 形式も許容するが、インストール先はフラットに
展開されるため、比較は basename (`${declared##*/}`) で行っている。

`shfmt` の差分がこのファイルに出るが main と同一の既存差分であり、
`.tmpl` は `shfmt -f` の対象外で CI の検査範囲にも入っていない。

#199（`OWN_PIN` を v0.3.0 へ）とは独立。両方入って初めて残骸が消える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)