### PR TITLE
feat(claude): 文章執筆系スキル2件を配布対象に加え、ピンを v0.4.0 へ更新

### DIFF
--- a/dot_claude/run_once_after_install_agent_skills.sh.tmpl
+++ b/dot_claude/run_once_after_install_agent_skills.sh.tmpl
@@ -10,7 +10,7 @@ set -euo pipefail
 # Skill list is fetched from install-sets/common.txt at the pinned ref so
 # agent-skills stays the single source of truth; bump OWN_PIN to refresh.
 OWN_REPO="ebal5/agent-skills"
-OWN_PIN="v0.3.0"
+OWN_PIN="v0.4.0"
 mapfile -t OWN_SKILLS < <(
   gh api "repos/${OWN_REPO}/contents/install-sets/common.txt?ref=${OWN_PIN}" \
     --jq '.content' | base64 -d \
@@ -25,7 +25,14 @@ if [ "${#OWN_SKILLS[@]}" -eq 0 ]; then
   exit 1
 fi
 
-for skill in "${OWN_SKILLS[@]}"; do
+# Skills agent-skills ships but deliberately keeps out of common.txt because it
+# does not consider them universal. Whether to put them on every machine is a
+# decision for the consuming side, so it is declared here. Also note that
+# cognitive-rhythm-writing reads ../japanese-tech-writing/SKILL.md at runtime,
+# so the two only work when installed together.
+OWN_EXTRA_SKILLS=(japanese-tech-writing cognitive-rhythm-writing)
+
+for skill in "${OWN_SKILLS[@]}" "${OWN_EXTRA_SKILLS[@]}"; do
   echo ">> gh skill install ${OWN_REPO} ${skill} --pin ${OWN_PIN}"
   gh skill install "${OWN_REPO}" "${skill}" \
     --agent claude-code --scope user --pin "${OWN_PIN}" --force
@@ -48,7 +55,7 @@ done
 # forever. Only skills whose SKILL.md records one of our two source repos are
 # eligible, which leaves manually installed skills untouched.
 SKILLS_DIR="${HOME}/.claude/skills"
-DECLARED=("${OWN_SKILLS[@]}" "${UPSTREAM_SKILLS[@]}")
+DECLARED=("${OWN_SKILLS[@]}" "${OWN_EXTRA_SKILLS[@]}" "${UPSTREAM_SKILLS[@]}")
 
 is_declared() {
   local candidate="$1" declared


### PR DESCRIPTION
## 変更

| 項目 | 内容 |
| --- | --- |
| `OWN_PIN` | `v0.3.0` → `v0.4.0`（`8f148eef`） |
| `OWN_EXTRA_SKILLS`（新設） | `japanese-tech-writing`, `cognitive-rhythm-writing` |
| `DECLARED` | `OWN_EXTRA_SKILLS` を追加 |

## 経緯

この2件はもともと `~/.claude/skills/` に手で置かれていたもので、出自不明のまま残っていた
（`gh skill install` が注入する `metadata.origin` を持たないことから、スクリプト経由でないと判別できた）。

agent-skills 側で調査した結果、出典は **k16shikano 氏の public gist**、
ライセンスは **Unlicense** と判明し、v0.4.0 でリポジトリに取り込まれた。
SkillSpector（`--no-llm`）でも両方 0/100 LOW / SAFE。

上流は「リポジトリには置くが `common.txt` には入れない」と判断している。
全マシンへ配りたいかどうかは利用側の都合なので、**こちら側で宣言する**。
`common.txt` は薄いまま保たれる。

## `DECLARED` に加える理由（重要）

これが本 PR の要点。`OWN_EXTRA_SKILLS` を `DECLARED` に入れないと、
#200 で入れた prune が両スキルを削除する。

1. 取り込み版に差し替えると `origin: ebal5/agent-skills` が付く
2. しかし `common.txt` には無い
3. prune は「自リポジトリ由来かつ宣言リストに無い」と判定 → **削除**

現在のコピーは `origin` を持たないため prune 対象外で、**この問題は差し替え後に初めて顕在化する**。
先回りして塞いでおく。

## ペア導入の必要性

`cognitive-rhythm-writing/SKILL.md:13` に相対パス依存がある。

```text
作業前に `../japanese-tech-writing/SKILL.md` を読む。
```

同じ配列に入れることで、片方だけ入る事態を防いでいる。

## 検証

```bash
git rev-parse v0.4.0^{commit}   # → 8f148eef3c15b7a61ad30e341e0f1e466b573377
git ls-tree --name-only v0.4.0 skills/   # → 両スキルが存在
gh skill preview ebal5/agent-skills japanese-tech-writing      # → 解決可
gh skill preview ebal5/agent-skills cognitive-rhythm-writing   # → 解決可
bash -n <テンプレート本体>       # → 構文OK
```

prune の fixture 検証を再実行した。**`origin` メタデータ付き（＝取り込み版に差し替わった状態）**で
両スキルを配置し、削除されないことを確認している。

| fixture | 由来 | 宣言 | 結果 |
| --- | --- | --- | --- |
| `japanese-tech-writing`, `cognitive-rhythm-writing` | 自リポジトリ | `OWN_EXTRA_SKILLS` | **保持** |
| `grilling`, `uv-script` | 自リポジトリ | `common.txt` | 保持 |
| `pdf` | anthropics | `UPSTREAM_SKILLS` | 保持 |
| `dev-workflow`, `review-loop`, `old-upstream` | 対象リポジトリ | なし | 削除 |
| `vendored-elsewhere` | `mattpocock/skills` | なし | 保持 |

ハーネスは `OWN_EXTRA_SKILLS` の定義をテンプレート本体から読み込んでおり、
テスト側で値を二重管理していない。

## マージ後

`chezmoi apply` で以下が起きる。

- 新規: `grilling` / `skill-audit` / `teach-me` / 執筆系2件（取り込み版へ差し替え）
- 削除: `dev-workflow` / `grill-me` / `review-loop`
- 全スキルの `github-pinned` が `v0.4.0` に揃う（`--force` 再インストールのため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)