### PR TITLE
chore(claude): agent-skills のピンを v1.0.0 へ更新

### DIFF
--- a/dot_claude/run_once_after_install_agent_skills.sh.tmpl
+++ b/dot_claude/run_once_after_install_agent_skills.sh.tmpl
@@ -9,8 +9,12 @@ set -euo pipefail
 # ebal5/agent-skills — own repo with semver tags.
 # Skill list is fetched from install-sets/common.txt at the pinned ref so
 # agent-skills stays the single source of truth; bump OWN_PIN to refresh.
+#
+# From v1.0.0 the tag carries a contract: major means a name we pin here can
+# disappear (skill removed or renamed), so a major bump is the one that needs
+# the lists below re-checked. minor adds skills, patch edits their contents.
 OWN_REPO="ebal5/agent-skills"
-OWN_PIN="v0.4.0"
+OWN_PIN="v1.0.0"
 mapfile -t OWN_SKILLS < <(
   gh api "repos/${OWN_REPO}/contents/install-sets/common.txt?ref=${OWN_PIN}" \
     --jq '.content' | base64 -d \


### PR DESCRIPTION
## 変更

`OWN_PIN` を `v0.4.0` → `v1.0.0`（`a70a4981`）へ。

**配布物の内容は v0.4.0 と同一**で、番号だけを上げた宣言的なリリース。

```console
$ git diff --quiet v0.4.0 v1.0.0 -- skills/ install-sets/ && echo "差分なし"
差分なし
```

スキルの追加・削除・改名が無いため、`OWN_EXTRA_SKILLS` / `UPSTREAM_SKILLS` /
prune の宣言リストへの影響もない。

## v1.0.0 以降のタグの意味

上流が semver の契約を明示したので、コメントとして記録した。

| 段 | 意味 | こちら側への影響 |
| --- | --- | --- |
| major | pin している名前が消える（スキル削除・改名） | **`gh skill install` が失敗しうる。リストの点検が必要** |
| minor | スキル追加 | 既存の名前は消えない |
| patch | 既存スキルの内容更新 | 同上 |

0.x では追加と削除が同じ minor に潰れていた。実際 v0.3.0 は追加5件と削除3件が
混在しており、番号から危険を読み取れなかった。#200 で prune が必要になったのも
これが一因。今後は **major のときだけ点検すれば済む**。

## 補足

上流はタグの自動発行（`.github/workflows/release.yml`）を導入しており、
発行頻度が上がる可能性がある。毎タグ追随するか major のみ追随するかは、
運用として別途決める。本PRでは判断していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)