### PR TITLE
feat(claude): herdr 連携フックをラッパー経由の共有設定にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,12 @@ GitHub Actionsで上記に加え、JSON Schema検証、E2Eテスト（Ubuntu/Win
 - `git add`と`git commit`は`&&`で繋げず、**別々のBash呼び出し**で実行すること。
   許可ツール設定が個別コマンドパターンのため、連結すると毎回許可確認が必要になる
 - `dot_claude/`内のファイルは`~/.claude/`に展開される（Claude Codeのグローバル設定）
+- `settings.json.src`に絶対パス（`/home/<user>/...`）を含むフックが混ざっていたら、
+  外部ツールが`~/.claude/settings.json`（このファイルへのシンボリックリンク）を
+  書き換えた痕跡。共有設定に固定パスを入れず、`~/.scripts/`のラッパー経由にする
+  （herdrの例は[README](README.md)の「フック」節を参照）
+- フックスクリプトは`set -e`を使っても最終的に`exit 0`で終わること。
+  非ゼロ終了はセッション側にエラーとして表示される
 
 ## Markdownテーブルスタイル
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,28 @@ git config user.signingkey "$(ssh-add -L | grep 'SOME_CONDITION')"
 | `CLAUDE.md` | 全プロジェクト共通の指示 |
 | `commands/` | カスタムスラッシュコマンド |
 
+### フック
+
+`settings.json`のSessionStart/SessionEndから`~/.scripts/`のスクリプトを呼び出す。
+
+| スクリプト | 役割 |
+| --- | --- |
+| `tmux_claude_title.sh` | tmuxウィンドウタイトルの設定・復帰 |
+| `herdr_agent_state.sh` | herdrへのエージェント状態通知（ラッパー） |
+
+`herdr_agent_state.sh`は`~/.claude/hooks/herdr-agent-state.sh`への薄いラッパー。
+委譲先はherdr管理（更新で上書きされる）なのでリポジトリには含めず、
+存在すれば実行し、herdr外や未インストール時は何もせず終了する。
+有効化はマシンごとに一度だけ`herdr integration install claude`を実行する。
+
+herdrのインストーラは`bash '/home/<user>/.claude/hooks/herdr-agent-state.sh' session`
+という絶対パスのフックを`settings.json`へ追記する。
+`~/.claude/settings.json`は`dot_claude/settings.json.src`へのシンボリックリンクなので、
+放置するとユーザー名込みの固定パスがリポジトリに入る。追記されていたら削除してよい
+（ラッパーが同じ役割を果たす）。herdr側の重複検出はコマンド文字列の完全一致なので
+ラッパー形式は認識されず、`herdr integration install`を実行するたび再追記される
+（`herdr update`が内部で再実行するかは未確認）。両方残っても通知は冪等で害はない。
+
 ### カスタムスラッシュコマンド
 
 | コマンド | 説明 |

--- a/dot_claude/settings.json.src
+++ b/dot_claude/settings.json.src
@@ -103,6 +103,11 @@
           {
             "type": "command",
             "command": "~/.scripts/tmux_claude_title.sh session-start"
+          },
+          {
+            "type": "command",
+            "command": "~/.scripts/herdr_agent_state.sh session",
+            "timeout": 10
           }
         ]
       }

--- a/dot_scripts/executable_herdr_agent_state.sh
+++ b/dot_scripts/executable_herdr_agent_state.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# herdr の Claude Code 連携フックを「入っていれば呼ぶ、無ければ黙って何もしない」
+# 形で包むラッパー。
+#
+# 委譲先の ~/.claude/hooks/herdr-agent-state.sh は herdr 管理
+# （`herdr integration install claude` が生成し、更新で上書きされる）なので
+# このリポジトリでは複製せず、存在すれば実行するだけにする。
+#
+# 方針:
+#   - フックの失敗でセッションを妨げないよう、最終的な終了コードは常に 0
+#   - stdin のフック JSON は委譲先が読むため、素通しする（読み捨て禁止）
+#   - socket や pane の判定は委譲先が持っているのでここでは重複させない。
+#     HERDR_ENV だけは安価な早期終了のために意図的に二重化している
+#     （herdr 側がこの変数をやめたらここの判定も外す）
+set -uo pipefail
+
+action="${1:-session}"
+
+# 未インストール／herdr 外の早期終了時は、書き込み側に EPIPE を返さないよう
+# stdin を読み捨てておく
+drain_stdin_and_exit() {
+  cat >/dev/null 2>&1 || true
+  exit 0
+}
+
+# herdr 配下で動いていないなら何もしない（HERDR_ENV は herdr が注入する）
+if [[ "${HERDR_ENV:-}" != "1" ]]; then
+  drain_stdin_and_exit
+fi
+
+# 委譲先を探す。herdr のインストーラは $HOME 基準で書き込むが、
+# CLAUDE_CONFIG_DIR を使う環境も候補に含める。
+# インストーラは実行権限を付けるので、実行できないものは未インストール扱いにし、
+# shebang を無視して sh で起動するようなことはしない
+hook=""
+for dir in "$HOME/.claude" "${CLAUDE_CONFIG_DIR:-}"; do
+  [[ -n "$dir" ]] || continue
+  if [[ -x "$dir/hooks/herdr-agent-state.sh" ]]; then
+    hook="$dir/hooks/herdr-agent-state.sh"
+    break
+  fi
+done
+
+# 連携未インストール（`herdr integration install claude` で導入）
+if [[ -z "$hook" ]]; then
+  drain_stdin_and_exit
+fi
+
+"$hook" "$action" || true
+
+exit 0


### PR DESCRIPTION
## 背景

`herdr integration install claude` は `~/.claude/settings.json` に
`bash '/home/<user>/.claude/hooks/herdr-agent-state.sh' session` という
**絶対パスのフック**を追記する。`~/.claude/settings.json` は
`dot_claude/settings.json.src` へのシンボリックリンクなので、これがそのまま
共有設定に入り込む。ユーザー名込みの固定パスであり、連携が未インストールの
マシンでは存在しないファイルを叩いて毎セッション非ゼロ終了する。

## 変更

`~/.scripts/herdr_agent_state.sh` を新設し、settings.json からはこれを呼ぶ。

- 委譲先を `$HOME/.claude/hooks/`（次に `$CLAUDE_CONFIG_DIR`）から探すので固定パスが消える
- 実行可能な委譲先が無ければ未インストール扱いで静かに終了。herdr 外（`HERDR_ENV != 1`）も同様
- 委譲先が失敗しても最終終了コードは常に 0
- stdin のフック JSON は素通し（委譲先は `session_id` を読む。読み捨てると静かに連携が死ぬ）
- 委譲先は herdr 管理で更新時に上書きされるためリポジトリには含めない

## 検証

- スタブ委譲先による7ケース（stdin 到達 / 未インストール無音 / herdr 外で非委譲 / 失敗の吸収 / 実行権限なし / `CLAUDE_CONFIG_DIR` / 実物スクリプト）すべて PASS
- 実 socket 経由で実物の委譲先を一度通し、exit 0・無出力を確認
- shfmt / shellcheck / markdownlint / `check-jsonschema`（CI と同一）clean
- `chezmoi diff` で `~/.scripts/herdr_agent_state.sh` が 100755 で配置されることを確認

## 既知の制約

herdr 側の重複検出はコマンド文字列の完全一致なので、ラッパー形式は認識されず
`herdr integration install` を実行するたび絶対パスのエントリが再追記される
（`herdr update` が内部で再実行するかは未確認）。両方残っても通知は冪等で害はない。
検出されたら削除してよい旨を README に記載した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)