### PR TITLE
feat(ci): 共有設定へのマシン固有・組織固有値の混入を検出する

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,12 +1,27 @@
 ---
-description: セキュリティ検証済みコンポーネント
+description: セキュリティ検証済みコンポーネントと共有設定の取り扱い
 ---
 
-# セキュリティ検証済みコンポーネント
+# セキュリティ
+
+## 共有設定の取り扱い
+
+このリポジトリは**public**。そして`~/.claude/settings.json`と`~/.claude/.mcp.json`は
+`dot_claude/*.src`へのシンボリックリンクなので、Claude Code自身やherdr等の
+外部ツールが書き込んだ内容が、そのまま作業ツリーに現れる。
+
+- 業務プロジェクトの組織名・リポジトリ名・社内ドメイン・ローカルパスが
+  `autoMode`や`hooks`として書き込まれることが実際にあった
+- `dot_claude/*.src`をステージする前に`git diff`で中身を確認すること
+- `.github/scripts/check-shared-settings.sh`が機械的に検出する
+  （pre-commit経由は`prek install`、CIは`shared-settings-guard.yaml`）
+- 環境依存の値を共有設定に入れず、`~/.scripts/`のラッパー経由にする
+
+## セキュリティ検証済みコンポーネント
 
 以下のコンポーネントは事前にセキュリティ検証が完了しており、一定期間はセキュリティレビューの対象外とします。
 
-## Bitwarden SSH Agent
+### Bitwarden SSH Agent
 
 - **リポジトリ**: <https://github.com/joaojacome/bitwarden-ssh-agent.git>
 - **コミットハッシュ**: `6237a3604d640533ad4123d23e23ddfd4e3666d2`

--- a/.github/scripts/check-shared-settings.sh
+++ b/.github/scripts/check-shared-settings.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# 共有設定ファイル（dot_claude/*.src）に、マシン固有・組織固有の値が
+# 混入したまま commit されるのを防ぐ。
+#
+# これらのファイルは ~/.claude/ のシンボリックリンク先であり、
+# Claude Code や herdr などの外部ツールが直接書き込む。
+# public リポジトリなので、書き込まれた内容はそのまま公開されうる。
+#
+# 判定は allowlist 方式。禁止したい顧客名をリポジトリに書くとそれ自体が
+# 流出になるため、既知の公開ホスト／オーナー以外を弾く形にし、
+# 固有名詞のリストはマシンローカル（DENYLIST）に置く。
+set -euo pipefail
+
+# 公開して差し支えない GitHub オーナー
+ALLOWED_OWNERS="ebal5 anthropics oraios joaojacome"
+# 公開して差し支えないホスト名
+ALLOWED_HOSTS="github.com raw.githubusercontent.com claude.ai docs.anthropic.com
+json.schemastore.org mcp.context7.com nixos.org starship.rs chezmoi.io"
+# マシンローカルの追加禁止語（1行1パターン、存在する場合のみ適用）
+DENYLIST="${HOME}/.config/local/shared-settings-denylist"
+
+DEFAULT_TARGETS="dot_claude/settings.json.src dot_claude/dot_mcp.json.src"
+
+status=0
+
+fail() {
+  printf '%s:%s: %s\n' "$1" "$2" "$3" >&2
+  status=1
+}
+
+# 前後を空白で挟み、"$list" == *" $needle "* の形で照合できるようにする
+OWNER_SET=" ${ALLOWED_OWNERS//[[:space:]]/ } "
+HOST_SET=" ${ALLOWED_HOSTS//[[:space:]]/ } "
+
+check_line() {
+  local file="$1" lineno="$2" line="$3"
+  local owner host pattern
+
+  # 1. マシン固有の絶対パス
+  if [[ "$line" =~ (/home/|/Users/|/root/|[A-Za-z]:\\Users\\) ]]; then
+    fail "$file" "$lineno" "マシン固有の絶対パス: ${BASH_REMATCH[1]}"
+  fi
+
+  # 2. allowlist 外の GitHub オーナー
+  if [[ "$line" =~ github\.com[:/]([A-Za-z0-9_.-]+)/ ]]; then
+    owner="${BASH_REMATCH[1]}"
+    if [[ "$OWNER_SET" != *" $owner "* ]]; then
+      fail "$file" "$lineno" "未知の GitHub オーナー: $owner"
+    fi
+  fi
+
+  # 3. allowlist 外のホスト名
+  for host in $(grep -oE '\b[A-Za-z0-9][A-Za-z0-9-]*(\.[A-Za-z0-9-]+)+\.(com|net|org|io|dev|ai|jp|cloud|app|me)\b' <<<"$line" || true); do
+    if [[ "$HOST_SET" != *" $host "* ]]; then
+      fail "$file" "$lineno" "未知のホスト名: $host"
+    fi
+  done
+
+  # 4. マシンローカルの禁止語
+  if [[ -f "$DENYLIST" ]]; then
+    while IFS= read -r pattern; do
+      if [[ -z "$pattern" || "$pattern" == \#* ]]; then
+        continue
+      fi
+      if grep -qiF -- "$pattern" <<<"$line"; then
+        fail "$file" "$lineno" "ローカル denylist に一致"
+      fi
+    done <"$DENYLIST"
+  fi
+}
+
+check_file() {
+  local file="$1" index
+  local -a lines=()
+  mapfile -t lines <"$file"
+  for index in "${!lines[@]}"; do
+    check_line "$file" "$((index + 1))" "${lines[index]}"
+  done
+}
+
+targets=("$@")
+if [[ ${#targets[@]} -eq 0 ]]; then
+  # shellcheck disable=SC2206 # 空白区切りの固定リストなので分割してよい
+  targets=($DEFAULT_TARGETS)
+fi
+
+for target in "${targets[@]}"; do
+  if [[ -f "$target" ]]; then
+    check_file "$target"
+  fi
+done
+
+if [[ $status -ne 0 ]]; then
+  cat >&2 <<'MSG'
+
+共有設定にマシン固有・組織固有の値が入っている。
+これらのファイルは ~/.claude/ のシンボリックリンク先で、外部ツールが直接書き込む。
+該当箇所を削除するか、環境非依存の形（~/.scripts/ のラッパー等）に置き換えること。
+正当な追加であれば .github/scripts/check-shared-settings.sh の allowlist を更新する。
+MSG
+fi
+
+exit "$status"

--- a/.github/workflows/shared-settings-guard.yaml
+++ b/.github/workflows/shared-settings-guard.yaml
@@ -1,0 +1,20 @@
+---
+name: Shared Settings Guard
+
+on:
+  pull_request:
+    paths:
+      - "dot_claude/settings.json.src"
+      - "dot_claude/dot_mcp.json.src"
+      - ".github/scripts/check-shared-settings.sh"
+
+jobs:
+  guard:
+    name: Check shared settings
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for machine/org specific values
+        run: .github/scripts/check-shared-settings.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+---
+# prek（`pre-commit` エイリアス）で実行する。導入は `prek install`。
+# CI でも同じスクリプトを実行するため、フックを飛ばしても最終的には検出される。
+repos:
+  - repo: local
+    hooks:
+      - id: shared-settings-guard
+        name: shared settings guard
+        description: 共有設定へのマシン固有・組織固有の値の混入を防ぐ
+        entry: .github/scripts/check-shared-settings.sh
+        language: script
+        files: ^dot_claude/(settings\.json\.src|dot_mcp\.json\.src)$
+        pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ git config commit.gpgsign true
 git config user.signingkey "$(ssh-add -L | grep 'SOME_CONDITION')"
 ```
 
+### pre-commitフックの導入（このリポジトリを編集する場合）
+
+```sh
+prek install
+```
+
+共有設定にマシン固有・組織固有の値が混入していないかを commit 時に検査する
+（[後述](#共有設定へのマシン固有値の混入防止)）。
+
 ### ユーザーレベルGitignore設定
 
 このdotfilesは `~/.config/git/ignore` にユーザーレベルのgitignoreファイルを設定します。
@@ -299,6 +308,35 @@ allowed-tools: Edit, Bash(npm:*)
 - `.claude/settings.json` - プロジェクト共有設定
 - `.claude/settings.local.json` - ローカル専用設定（gitignore推奨）
 - `.claude/.mcp.json` - ローカル専用MCPサーバー（gitignore推奨）
+
+### 共有設定へのマシン固有値の混入防止
+
+`~/.claude/settings.json`と`~/.claude/.mcp.json`は`dot_claude/*.src`への
+シンボリックリンクであり、Claude Code自身や外部ツール（herdr等）が直接書き込む。
+このリポジトリはpublicなので、書き込まれた内容はそのまま公開されうる。
+実際にauto modeが学習した業務プロジェクトの組織名・社内ドメイン・
+ローカルパスが作業ツリーに書き込まれたことがある。
+
+`.github/scripts/check-shared-settings.sh`がこれを検出する。
+
+| 検出対象 | 例 |
+| --- | --- |
+| マシン固有の絶対パス | `/home/<user>/...`, `C:\Users\...` |
+| 未知のGitHubオーナー | allowlist外の`github.com:<org>/<repo>` |
+| 未知のホスト名 | 社内ドメインなど、allowlist外のホスト |
+| ローカルdenylist該当語 | `~/.config/local/shared-settings-denylist`（任意） |
+
+禁止語のリストをリポジトリに置くとそれ自体が流出になるため、判定はallowlist方式。
+固有名詞を弾きたい場合のみ、マシンローカルの
+`~/.config/local/shared-settings-denylist`（1行1パターン）に記述する。
+
+実行経路は2つ:
+
+- pre-commit（[prek](https://github.com/j178/prek)）: `prek install`で導入。`.pre-commit-config.yaml`を参照
+- GitHub Actions: `shared-settings-guard.yaml`が該当ファイルの変更時に実行
+
+正当な追加でフックが落ちる場合は、スクリプト冒頭の`ALLOWED_OWNERS`／
+`ALLOWED_HOSTS`を更新する。
 
 ## チェック内容
 


### PR DESCRIPTION
## 背景

`~/.claude/settings.json` と `~/.claude/.mcp.json` は `dot_claude/*.src` への
シンボリックリンクで、Claude Code 自身や herdr などの外部ツールが直接書き込む。
このリポジトリは public なので、書き込まれた内容はそのまま公開されうる。

実際に、auto mode が学習した業務プロジェクトの情報（GitHub org 名、private
リポジトリ名、社内ドメイン、`/home/<user>/Projects/...` のローカルパス）が
`autoMode.environment` として作業ツリーに現れていた。**未コミット・未 push で、
`git log -S` でも履歴に無いことを確認済み**。作業ツリー側は別途手で除去した。

herdr の絶対パスフックも同じ経路で入ってきたもの（#204）。

## 変更

`.github/scripts/check-shared-settings.sh` を追加し、pre-commit と CI の
両方から同じスクリプトを実行する。

| 検出対象 | 例 |
| --- | --- |
| マシン固有の絶対パス | `/home/<user>/...`, `C:\Users\...` |
| 未知の GitHub オーナー | allowlist 外の `github.com:<org>/<repo>` |
| 未知のホスト名 | 社内ドメインなど allowlist 外のホスト |
| ローカル denylist 該当語 | `~/.config/local/shared-settings-denylist`（任意） |

**判定は allowlist 方式**。禁止したい顧客名をリポジトリに書くとそれ自体が流出に
なるため、既知の公開ホスト／オーナー以外を弾く形にし、固有名詞はマシンローカルの
denylist にのみ置く（CI では存在しないので自動的にスキップされる）。

## 検証

- 現在の `settings.json.src` / `dot_mcp.json.src`: PASS
- 流出していた版（除去前のバックアップ）: 5 件すべて検出して FAIL
  - herdr の `/home/` 絶対パス、GitHub org 名 ×2、社内ドメイン、ローカルパス
- `prek run --all-files` で pass / fail 両方の挙動を確認
- shellcheck（`enable=all`）、shfmt、markdownlint、actionlint すべて clean

## 補足

pre-commit は `prek install` で導入する（`prek` は Nix 管理済み・`pre-commit`
エイリアス設定済み）。フックを飛ばしても CI 側で同じスクリプトが走る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)