### PR TITLE
fix(ci): bot 作成 PR で auto-assign が失敗する問題を修正

### DIFF
--- a/.github/workflows/flake-lock-update.yaml
+++ b/.github/workflows/flake-lock-update.yaml
@@ -116,15 +116,15 @@ jobs:
             echo "### 固定リビジョンの変化"
             echo
             echo '```diff'
-            diff -u /tmp/lock-before.txt /tmp/lock-after.txt || true
+            diff -u --label before --label after /tmp/lock-before.txt /tmp/lock-after.txt || true
             echo '```'
             echo
             echo "### 補足"
             echo
-            echo "\`GITHUB_TOKEN\` で作成した PR は workflow をトリガーしないため、"
-            echo "この PR には CI チェックが付かない。再現性チェックは上記の実行ログ内で"
-            echo "実施済み。E2E などを走らせたい場合は \`gh pr update-branch\` などで"
-            echo "コミットを積み直すか、ローカルで確認する。"
+            echo "\`GITHUB_TOKEN\` で作成した PR の workflow は自動では開始せず、"
+            echo "\`action_required\` の状態で保留される。再現性チェックは上記の実行ログ内で"
+            echo "実施済みなので必須ではないが、E2E などを走らせたい場合は Actions 画面から"
+            echo "保留中の run を承認するか、下記の手順でローカル確認する。"
             echo
             echo "### ローカルでの確認手順"
             echo

--- a/.github/workflows/flake-lock-update.yaml
+++ b/.github/workflows/flake-lock-update.yaml
@@ -121,10 +121,9 @@ jobs:
             echo
             echo "### 補足"
             echo
-            echo "\`GITHUB_TOKEN\` で作成した PR の workflow は自動では開始せず、"
-            echo "\`action_required\` の状態で保留される。再現性チェックは上記の実行ログ内で"
-            echo "実施済みなので必須ではないが、E2E などを走らせたい場合は Actions 画面から"
-            echo "保留中の run を承認するか、下記の手順でローカル確認する。"
+            echo "\`GITHUB_TOKEN\` で作成した PR では CI が自動で走らないことがある。"
+            echo "再現性チェックは上記の実行ログ内で実施済み。E2E などを走らせたい場合は、"
+            echo "Actions 画面に保留中の run があれば承認するか、下記の手順でローカル確認する。"
             echo
             echo "### ローカルでの確認手順"
             echo

--- a/.github/workflows/pr-auto-assign.yaml
+++ b/.github/workflows/pr-auto-assign.yaml
@@ -16,9 +16,16 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            const author = context.payload.pull_request.user;
+            const isBot = author.type === 'Bot' || author.login.endsWith('[bot]');
+
+            // bot が作成した PR で bot 自身を assignee に指定すると API が 403 を返すため、
+            // リポジトリオーナーを代わりに割り当てる
+            const assignee = isBot ? context.repo.owner : author.login;
+
             await github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              assignees: [context.payload.pull_request.user.login]
+              assignees: [assignee]
             });


### PR DESCRIPTION
## 背景

flake.lock 週次更新 PR (#203) で `PR Auto Assign` が失敗していた。

```text
POST /repos/ebal5/dotfiles-chezmoi/issues/203/assignees
body: {"assignees":["github-actions[bot]"]}
=> 403 Forbidden
```

API が `github-actions[bot]` を assignee として受け付けないため、
bot が作成した PR では必ず落ちる。

## 変更

1. **`pr-auto-assign.yaml`** — 作成者が bot の場合はリポジトリオーナーを
   assignee にフォールバックする。自動 PR も「自分にアサインされた PR」の
   一覧に出るようになる。判定は `user.type === 'Bot'` と login の
   `[bot]` サフィックスの両方で行う。
2. **`flake-lock-update.yaml`（PR 本文の補足）** — 「この PR には CI チェックが
   付かない」という記述が実態と食い違っていた。#203 では run 自体は作成され、
   `action_required` として保留されたあと承認で全て pass している。
   ただし保留されるかどうかは Actions の承認要求設定に依存するので、
   特定の状態を断定せず「保留 run があれば承認、無ければローカル確認」という
   設定非依存の書き方に変更した。あわせてマージ可否の判断は本文から外した。
3. **`flake-lock-update.yaml`（diff ラベル）** — public な PR 本文に
   `/tmp/lock-before.txt 2026-08-17 09:48:13 +0000` のようなランナーの
   一時パスとタイムスタンプが出ていたので `diff -u --label` で抑制。

## 検証

- `actionlint` — pass（CI の Lint GitHub Actions workflows も pass）
- この PR 自身が人間作成なので auto-assign の human パスは実測済み
  （assignee に `ebal5` が付き `Assign PR author` が pass）。
  bot パスは次回の週次更新 PR で確認する。

## 別途対応が必要（この PR の範囲外）

保留中 run の承認が毎週の手作業として残る。不要なら
Settings → Actions → General の承認要求設定を見直す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
