### PR TITLE
feat(herdr): プラグインを commit SHA 固定で導入する仕組みを追加

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -65,6 +65,7 @@ flake.lock
 .profile
 .scripts/
 .config/sh-like-aliases
+.config/herdr-plugins
 .config/tmux/
 executable_once_setup_ubuntu.sh.tmpl
 {{ end }}

--- a/README.md
+++ b/README.md
@@ -196,6 +196,60 @@ WSLでは`win32yank.exe`（テキスト）と`powershell.exe`（画像）、
 それ以外のLinuxでは`xclip`、無ければ`xsel`（テキストのみ）を使う。
 保存先パスは標準出力にも出るため`file=$(c2f)`のように受け取れる。
 
+### herdrプラグイン
+
+herdrのプラグインはサンドボックス無しで自分の権限のまま動く任意コードで、
+herdr側には署名検証もチェックサムも`plugin update`も無い
+（マーケットプレイスもGitHubトピックの自動収集で審査は無い）。
+そのため`herdr plugin install`は使わない。あれはプラグイン側の`[[build]]`を
+無条件に実行し、checkoutをherdr管理下に置いて再インストールで差し替えるため、
+「監査した木」と「動いている木」が一致しない。
+
+代わりに[dot_config/herdr-plugins](dot_config/herdr-plugins)へ
+**完全な40桁commit SHA**でピン止めし、
+`run_onchange_after_install_herdr_plugins.sh.tmpl`が次を行う。
+
+1. `~/.local/share/herdr-plugins/<owner>_<repo>`へ`git fetch --depth 1 <SHA>`で取得
+2. checkoutのHEADがピンと一致するか照合（不一致なら登録しない）
+3. 定義ファイルに書いたビルドコマンドだけを実行（herdr側の`[[build]]`は走らない）
+4. `herdr plugin link`で登録
+
+結果として、**何が実行されるかは定義ファイルの1行だけで決まり、
+バージョン更新はPRのdiffに現れる**。
+
+| 状況 | 挙動 |
+| --- | --- |
+| 定義ファイル未変更 | 何もしない（`run_onchange_`） |
+| SHA変更 | `git clean -xdff`してから再取得・再ビルド |
+| ビルド失敗 | linkせずに次のプラグインへ進む |
+| 定義から削除 | `herdr plugin unlink`してcheckoutごと削除 |
+| 手動でunlink済み | 次回applyで再link |
+| herdr未導入 | 何もせず終了 |
+
+導入済み:
+
+| プラグイン | 用途 | 依存の扱い |
+| --- | --- | --- |
+| `jt.command-palette` | fzfによる全プラグインアクションの一覧・実行 | bash 2本のみ。fzf/jqはNix管理 |
+| `tdi.worktree-setup` | worktree作成時のper-projectセットアップ実行 | npm依存はsmol-toml 1個。`npm ci --ignore-scripts` |
+
+選定基準は2つ。lockfileを固定してビルドできること
+（`npm install`しか用意がないものは入れない）と、
+ツールチェーンをこのマシンに持ち込まないこと。
+後者でRust製プラグインは見送っている（理由は定義ファイルのコメントに残してある）。
+
+プラグインごとの設定は`~/.config/herdr/plugins/config/<plugin-id>/config.toml`に置く
+（`herdr plugin config-dir <plugin-id>`で確認できる）。リポジトリ管理外。
+キーバインドはherdrのマニフェストからは効かないため`~/.config/herdr/config.toml`に書く。
+
+```toml
+[[keys.command]]
+key = "prefix+p"
+type = "plugin_action"
+command = "jt.command-palette.open"
+description = "Command palette"
+```
+
 ### 主な Git コマンドのエイリアス
 
 | エイリアス | 展開 | 備考 |

--- a/dot_config/herdr-plugins
+++ b/dot_config/herdr-plugins
@@ -1,0 +1,44 @@
+# herdr プラグインのピン止め定義
+# run_onchange_after_install_herdr_plugins.sh.tmpl が読み込む
+#
+# 形式: <owner>/<repo>[/<subdir>]  <40桁commit SHA>  [ビルドコマンド]
+#   - SHA は完全な 40 桁のみ。タグ・ブランチは不可（取得後に HEAD と照合する）
+#   - ビルドコマンドはプラグインディレクトリで `sh -c` 実行。省略可
+#   - 登録は `herdr plugin install` ではなく `herdr plugin link`。
+#     link はプラグイン側の [[build]] を実行しないので、何が走るかは
+#     この定義ファイルに書いたコマンドだけで決まる
+#
+# 追加・更新の手順:
+#   1. リポジトリを clone して herdr-plugin.toml を読む
+#      （startup / events / build / link_handlers が自動実行される面）
+#   2. 依存があるなら lockfile 固定でビルドできることを確認する
+#      （npm ci --ignore-scripts など。lockfile が無いものは入れない）。
+#      ツールチェーンをこのマシンに持ち込むもの（Rust など）は入れない
+#   3. 更新時は git log <old-sha>..<new-sha> と diff を読んでから SHA を書き換える
+
+# fzf コマンドパレット (v0.1.0)
+# bash スクリプト 2 本のみ、ビルド無し。依存は fzf/jq で both Nix 管理。全文監査済み
+JanTvrdik/herdr-command-palette  eab940018c2135ac23718efa11e23e9dddcd2a75
+
+# worktree 作成時に per-project セットアップを実行 (v0.2.0)
+# npm 依存は smol-toml 1 個のみ（integrity 付き lock をコミット済み）。
+# 実行するステップは ~/.config/herdr/plugins/config/tdi.worktree-setup/config.toml
+# から読む＝レビュー対象リポジトリ側から注入される経路は無い。全文監査済み
+tdi/herdr-worktree-setup  4527a11bd5444dbce34c3d4f459b49d704cc12a7  npm ci --ignore-scripts
+
+# 見送り — Rust ツールチェーンを要求するものは入れない方針
+#
+# エージェントの差分レビューペイン (v0.32.1)。ソース側の素性は悪くない
+# （MIT / star 458 / cargo-audit + dependabot / SECURITY.md）が、Cargo.lock 固定で
+# 自前ビルドする＝rustup のツールチェーンと 337 crates をこのマシンに持ち込む。
+# 本体の [[build]] が使う Release のビルド済みバイナリ（sha256 検証あり）に切り替えれば
+# Rust は不要になるが、検証の対象がピン留めしたソースから作者の Release 成果物と
+# その CI へ移る。それなら入れない方を選んだ
+#persiyanov/herdr-reviewr  a4224541751a5030986e159aedb69e6508716e15  cargo build --release --locked && install -D -m 0755 target/release/herdr-reviewr bin/herdr-reviewr
+
+# 監査保留 — 有効化するなら行頭の # を外す
+# Claude Code のエージェントチームを herdr 上で起動・操作する。権限は最も重いのに、
+# Rust 26k 行を 2 日で生成した AI 製リポジトリで全量監査が非現実的、star 20 /
+# 単独著者 / 最終更新 2026-07-17。ビルドが ~/.local/bin に herdmates を置く
+# （actions が PATH 上の bare argv を叩くため、link 運用でもここは避けられない）
+#caioniehues/herdmates  9469ab2abeea4d593906ff7eebb8af22cd22b8e0  cargo install --path . --root "$HOME/.local"

--- a/run_onchange_after_install_herdr_plugins.sh.tmpl
+++ b/run_onchange_after_install_herdr_plugins.sh.tmpl
@@ -1,0 +1,183 @@
+{{ if ne .chezmoi.os "windows" -}}
+#!/bin/sh
+# Install herdr plugins pinned in ~/.config/herdr-plugins
+#
+# 完全な commit SHA で取得 → HEAD と照合 → 定義ファイルのコマンドでビルド →
+# `herdr plugin link` で登録する。`herdr plugin install` を使わないのは、
+# install が (1) プラグイン側の [[build]] を無条件に実行し (2) checkout を
+# herdr 管理下に置いて再インストールで差し替えるため。link ならビルドは走らず、
+# 監査した木がそのまま動く木になる。
+#
+# definitions: {{ include "dot_config/herdr-plugins" | sha256sum }}
+
+set -eu
+
+DEFS="$HOME/.config/herdr-plugins"
+ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/herdr-plugins"
+STATE="$ROOT/.state"
+
+[ -f "$DEFS" ] || exit 0
+
+if ! command -v herdr >/dev/null 2>&1; then
+  echo "herdr-plugins: herdr not found, skipping" >&2
+  exit 0
+fi
+
+mkdir -p "$STATE"
+
+# 登録済みか調べる。jq が無い環境では素の文字列一致にフォールバックする
+is_linked() {
+  if command -v jq >/dev/null 2>&1; then
+    herdr plugin list --json 2>/dev/null |
+      jq -e --arg id "$1" '.result.plugins[]? | select((.plugin_id // .id) == $id)' >/dev/null 2>&1
+  else
+    herdr plugin list --json 2>/dev/null | grep -qF "\"$1\""
+  fi
+}
+
+wanted=""
+
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    "#"* | "") continue ;;
+  esac
+
+  # source SHA [build...] へ分解する。ビルドコマンドに含まれる * を展開させない
+  set -f
+  # shellcheck disable=SC2086
+  set -- $line
+  set +f
+  [ $# -ge 2 ] || {
+    echo "herdr-plugins: WARNING: invalid line '$line', skipping" >&2
+    continue
+  }
+  spec="$1"
+  sha="$2"
+  shift 2
+  build="$*"
+
+  # SHA は 40 桁の hex のみ受け付ける。タグやブランチは可変なのでピンにならない
+  case "$sha" in
+    *[!0-9a-f]*)
+      echo "herdr-plugins: WARNING: '$sha' is not a commit SHA, skipping $spec" >&2
+      continue
+      ;;
+  esac
+  if [ ${#sha} -ne 40 ]; then
+    echo "herdr-plugins: WARNING: '$sha' is not a full 40-char SHA, skipping $spec" >&2
+    continue
+  fi
+
+  # owner/repo[/subdir]
+  case "$spec" in
+    */*) ;;
+    *)
+      echo "herdr-plugins: WARNING: '$spec' is not owner/repo, skipping" >&2
+      continue
+      ;;
+  esac
+  owner="${spec%%/*}"
+  rest="${spec#*/}"
+  repo="${rest%%/*}"
+  case "$rest" in
+    */*) subdir="${rest#*/}" ;;
+    *) subdir="" ;;
+  esac
+
+  key="${owner}_${repo}"
+  dir="$ROOT/$key"
+  stamp="$STATE/$key"
+  wanted="$wanted $key"
+
+  # 取得。herdr 自身と同じく shallow fetch + 明示 SHA
+  if [ ! -d "$dir/.git" ]; then
+    rm -rf "${dir:?}"
+    git init -q "$dir"
+    git -C "$dir" remote add origin "https://github.com/$owner/$repo.git"
+  fi
+  head=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+  if [ "$head" != "$sha" ]; then
+    echo "herdr-plugins: fetching $owner/$repo @ $sha"
+    if ! git -C "$dir" fetch -q --depth 1 origin "$sha"; then
+      echo "herdr-plugins: ERROR: fetch failed for $spec@$sha" >&2
+      continue
+    fi
+    git -C "$dir" reset -q --hard FETCH_HEAD
+    # 前バージョンのビルド成果物を残さない（node_modules, bin, target 等）
+    git -C "$dir" clean -qxdff
+  fi
+
+  # 取得したものがピン通りかを最終確認する
+  if [ "$(git -C "$dir" rev-parse HEAD)" != "$sha" ]; then
+    echo "herdr-plugins: ERROR: $spec HEAD does not match pinned $sha, refusing" >&2
+    continue
+  fi
+
+  plugin_dir="$dir"
+  [ -z "$subdir" ] || plugin_dir="$dir/$subdir"
+  manifest="$plugin_dir/herdr-plugin.toml"
+  if [ ! -f "$manifest" ]; then
+    echo "herdr-plugins: ERROR: no herdr-plugin.toml in $plugin_dir" >&2
+    continue
+  fi
+  id=$(sed -n 's/^id[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest" | head -1)
+  if [ -z "$id" ]; then
+    echo "herdr-plugins: ERROR: could not read plugin id from $manifest" >&2
+    continue
+  fi
+
+  # stamp は「この SHA でビルドと登録まで通った」印。SHA が動いたら作り直す
+  done_sha=""
+  [ ! -f "$stamp" ] || read -r done_sha _ <"$stamp" || done_sha=""
+
+  if [ -n "$build" ] && [ "$done_sha" != "$sha" ]; then
+    echo "herdr-plugins: building $id"
+    if ! (cd "$plugin_dir" && sh -c "$build"); then
+      echo "herdr-plugins: ERROR: build failed for $id, not linking" >&2
+      rm -f "$stamp"
+      continue
+    fi
+  fi
+
+  if is_linked "$id"; then
+    :
+  else
+    echo "herdr-plugins: linking $id"
+    if ! herdr plugin link "$plugin_dir" >/dev/null; then
+      echo "herdr-plugins: ERROR: link failed for $id" >&2
+      rm -f "$stamp"
+      continue
+    fi
+  fi
+
+  printf '%s %s\n' "$sha" "$id" >"$stamp"
+done <"$DEFS"
+
+# 定義から消えたプラグインを登録解除して checkout ごと削除する。
+# checkout と stamp の両方を候補にする（ビルド失敗で stamp の無い checkout が
+# 残っている場合や、逆に checkout だけ手で消された場合を取りこぼさない）
+stale=""
+for path in "$ROOT"/* "$STATE"/*; do
+  [ -e "$path" ] || continue
+  key=$(basename "$path")
+  case " $wanted $stale " in
+    *" $key "*) continue ;;
+  esac
+  stale="$stale $key"
+done
+
+# shellcheck disable=SC2086
+for key in $stale; do
+  stamp="$STATE/$key"
+  # stamp は link 成功後にだけ書かれる。無ければ未登録なので unlink は不要
+  if [ -f "$stamp" ]; then
+    read -r _ id <"$stamp" || id=""
+    if [ -n "$id" ]; then
+      echo "herdr-plugins: unlinking removed plugin $id"
+      herdr plugin unlink "$id" >/dev/null 2>&1 || true
+    fi
+  fi
+  echo "herdr-plugins: removing $key"
+  rm -rf "${ROOT:?}/${key:?}" "$stamp"
+done
+{{ end -}}


### PR DESCRIPTION
## 概要

herdr のプラグインを、サプライチェーン面で説明できる形で導入する仕組みを追加する。

herdr のプラグインは**サンドボックスなしで自分の権限のまま動く任意コード**（install 時の `[[build]]`、セッション毎の startup フック、イベントハンドラ）で、herdr 側には署名検証もチェックサムも `plugin update` も無い。マーケットプレイスも GitHub トピック `herdr-plugin` の自動収集で審査は無く、公式ドキュメントも "Discovery is automatic and unreviewed" と明記している。

## 方針

`herdr plugin install` を使わない。あれは

1. プラグイン側の `[[build]]` を無条件に実行する
2. checkout を herdr 管理下に置き、再インストールで差し替える

ため、「監査した木」と「動いている木」が一致しない。

代わりに `herdr plugin link`（build を実行しない）を使い、**何が実行されるかを定義ファイル側だけで決める**。

| ファイル | 役割 |
| --- | --- |
| `dot_config/herdr-plugins` | `owner/repo  40桁SHA  [ビルドコマンド]` のピン定義 |
| `run_onchange_after_install_herdr_plugins.sh.tmpl` | fetch → SHA 照合 → ビルド → link |

処理の流れ:

1. `~/.local/share/herdr-plugins/<owner>_<repo>` へ `git fetch --depth 1 <SHA>`
2. checkout の HEAD がピンと一致するか照合（不一致なら登録しない）
3. 定義ファイルに書いたビルドコマンドだけを実行
4. `herdr plugin link` で登録

結果として、バージョン更新は PR の diff に現れる。

## 導入するプラグイン

| プラグイン | 用途 | 依存 |
| --- | --- | --- |
| `jt.command-palette` | fzf による全プラグインアクションの一覧・実行 | bash 2本のみ。fzf/jq は Nix 管理 |
| `tdi.worktree-setup` | worktree 作成時の per-project セットアップ実行 | npm 依存は smol-toml 1個（integrity 付き lock）。`npm ci --ignore-scripts` |

どちらも全文監査済み。worktree-setup が実行するステップはユーザの config dir から読むため、レビュー対象リポジトリ側からコードを注入される経路は無い。

### 見送ったもの

- **`persiyanov/herdr-reviewr`**: ソースの素性は悪くない（MIT / star 458 / cargo-audit + dependabot / SECURITY.md）が、`--locked` で自前ビルドする＝ rustup のツールチェーンと 337 crates をマシンに持ち込む。Release のビルド済みバイナリ（sha256 検証あり）に切り替えれば Rust は不要になるが、検証対象がピン留めしたソースから作者の Release 成果物とその CI へ移るため見送り
- **`caioniehues/herdmates`**: Claude Code のエージェントチームを起動・操作する権限の重さに対し、Rust 26k 行を 2 日で生成した AI 製リポジトリで全量監査が非現実的、star 20 / 単独著者 / 最終更新 2026-07-17

いずれも理由付きで定義ファイルにコメントとして残してあるので、判断を変えるなら `#` を外すだけで入る。

## 動作確認

隔離した HOME と実環境の両方で確認済み。

- 初回導入（fetch → build → link）
- 冪等な再実行（定義未変更なら無出力）
- 定義から削除 → `herdr plugin unlink` + checkout 削除
- ビルド失敗 → link せずに次へ進む
- ビルド失敗で stamp の無い孤立 checkout も掃除される
- 手動 `herdr plugin unlink` 後の再 link（自己修復）
- herdr 未導入の環境では何もせず終了

lint は shellcheck / shfmt / markdownlint / shared-settings-guard すべてクリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)