### PR TITLE
docs(mise): ツール管理方針の判定基準を実態に合わせる

### DIFF
--- a/.claude/rules/mise-tools.md
+++ b/.claude/rules/mise-tools.md
@@ -8,7 +8,8 @@ description: mise（ツールバージョン管理）
 ## 概要
 
 mise（旧rtx）はプロジェクトごとのツールバージョン管理ツール。
-asdfの高速なRust実装として、Node.js、Python等の言語ランタイムを管理。
+asdfの高速なRust実装。Node.js、Python等の言語ランタイムに加え、
+プロジェクトごとにバージョンを固定したいツール（shellcheck、shfmt、terraform等）を管理する。
 
 ## 基本コマンド
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,12 @@ Ubuntu/WSL2環境向けのChezmoiで管理された個人用dotfilesリポジト
 
 - **Nix**（`flake.nix`）: CLIツール・開発コマンドの宣言的管理（starship, delta, fzf, ripgrep, git, chezmoi等）
 - **APT**: システム基盤・ビルド依存（lib*-dev, build-essential等）+ ブートストラップ用最小限ツール + root権限で使うツール（nmap, vim）
-- **mise**: 言語ランタイムのみ（Node.js, Python）
+- **mise**: プロジェクトごとにバージョンを固定する必要があるツール（Node.js, Python等のランタイム、shellcheck, shfmt等）
 - **winget**（Windows）: Nix CLIツールのWindows対応版 + Windows専用アプリ
 - **uvx/pnpm shim**（`dot_config/shim-definitions`）: `chezmoi apply`時に`~/.scripts/`へラッパースクリプトを自動生成。新ツール追加は定義ファイルに1行追加するだけ
-- 判定基準: CLIツール→Nix、ビルド依存→APT、ランタイム→mise、root権限必要→APT、Pythonツール(ruff等)→uvx shim、JSツール(markdownlint-cli2等)→pnpm shim
+- 判定基準: CLIツール→Nix、ビルド依存→APT、PJごとのバージョン固定が必要→mise、root権限必要→APT、Pythonツール(ruff等)→uvx shim、JSツール(markdownlint-cli2等)→pnpm shim
+- Nixはグローバルに1バージョンしか置けないため、PJごとに異なるバージョンを使い分けるツール（terraform等）はNixではなくmiseで管理する。
+  ただしグローバルの`~/.config/mise/config.toml`ではなく、各プロジェクトの`mise.toml`に書く
 
 ## 機械固有設定
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ prek install
   - ツールのバージョン更新: `git pull`で`flake.lock`を取得してから`nix profile upgrade --all`
   - `flake.lock`自体の更新は週次のGitHub Actionsが自動PR化する（後述）
 - [Starship](https://starship.rs/ja-jp/)
-- [mise (alt asdf)](https://github.com/jdx/mise)（言語ランタイム管理: Node.js、Python）
+- [mise (alt asdf)](https://github.com/jdx/mise)（プロジェクトごとにバージョン固定が必要なツールの管理: Node.js、Python等）
 - [uv](https://docs.astral.sh/uv/)（Pythonパッケージ管理・uvxによるツール実行）
 - Git config
   - diff として delta を利用
@@ -463,13 +463,20 @@ NOTE: markdownlintによるチェックとの違いは要検証
 
 手動実行は`workflow_dispatch`（ActionsタブのRun workflow）から可能。
 
-### mise管理ツール（言語ランタイム）
+### mise管理ツール
 
 mise設定（`~/.config/mise/config.toml`）はマシンローカルでリポジトリ管理外のため、
 CIによる自動化対象ではない。手動で更新する。
 
 ```bash
 mise upgrade
+```
+
+mise本体はNix・APTいずれの管理下にもなく、初回のみ`executable_once_setup_ubuntu.sh.tmpl`が
+公式インストーラで`~/.local/bin/mise`へ導入する。以降の更新は手動で行う。
+
+```bash
+mise self-update
 ```
 
 NOTE: Node.jsの更新にはリリース署名鍵の検証が必要。


### PR DESCRIPTION
## 背景

`mise self-update` が exit 1 で終わる件を調べたところ、self-update 自体は成功しており、
その後に走る `mise plugins update` が Nix 移行後に取り残された asdf プラグイン
（upstream 消滅済みの `zoxide` 等）の fetch に失敗していた。ローカル状態のドリフトで
リポジトリ側のバグではないため、プラグインの掃除はローカルで実施済み。

この調査の過程で、ドキュメントの記述と実態の乖離が見つかったのでそちらを修正する。

## 変更内容

`mise` の役割を「言語ランタイムのみ」と定義していたが、実際には shellcheck / shfmt も
マシンローカルの `config.toml` で管理しており、定義が実態に追いついていなかった。

これらを mise に置いている理由はランタイムだからではなく、プロジェクトごとに
バージョンを固定したいから。Nix はグローバルに1バージョンしか置けないため、
terraform のように PJ ごとの固定が必要なツールは Nix ではなく mise 側になる。

- 判定基準を「言語ランタイムか？」から「PJ ごとのバージョン固定が必要か？」へ変更
- この種のツールはグローバル設定ではなく各プロジェクトの `mise.toml` に書く旨を明記
- mise 本体が Nix / APT いずれの管理下にもなく、初回のみ公式インストーラで導入され
  以降は手動 `mise self-update` である点を README に追記

対象は `CLAUDE.md` / `README.md` / `.claude/rules/mise-tools.md` の3ファイル。

## 補足

`docs/superpowers/` 配下の日付付き設計・計画ドキュメントは、当時の決定記録なので
意図的に更新していない（旧方針の記述が残る）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)