### PR TITLE
feat(claude): output style を Concise にする

### DIFF
--- a/dot_claude/settings.json.src
+++ b/dot_claude/settings.json.src
@@ -131,6 +131,7 @@
   "enabledPlugins": {},
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",
+  "outputStyle": "Concise",
   "tui": "fullscreen",
   "teammateMode": "tmux",
   "advisorModel": "opus"


### PR DESCRIPTION
## 変更内容

`dot_claude/settings.json.src` に `"outputStyle": "Concise"` を追加し、
Claude Code のグローバルデフォルトを Concise スタイルにする。

## 根拠（公式情報）

- 設定キー: `outputStyle`（string）— [settings reference](https://code.claude.com/docs/en/settings-reference), [output styles](https://code.claude.com/docs/en/output-styles)
- 組み込みスタイル: `default` / `Proactive` / `Concise` / `Explanatory` / `Learning`
- `Concise` は Claude Code v2.1.237 で追加された組み込みスタイル（手元は 2.1.246）
  - 説明: 結果から述べ、前置きとナレーションを省く。作業自体の徹底度は変えない
  - 説明を求められた場合は完全に答える／エラー出力・セキュリティ警告・破壊的操作の確認は full content を保持

## 注意点

- Concise のスタイルプロンプトには「他の communication / formatting 指示と衝突する場合はこのルールが優先」と明記されている。
  グローバル CLAUDE.md の「最初のツール呼び出し前に一文で宣言する」等は上書きされる可能性がある
- output style はセッション開始時に一度読まれるため、反映は次セッション以降

## 検証

- `.github/scripts/check-shared-settings.sh` — Passed（pre-commit 経由でも Passed）
- `uvx check-jsonschema==0.37.0 --schemafile https://json.schemastore.org/claude-code-settings.json dot_claude/settings.json.src` — ok
  - schemastore 側の description は組み込み一覧が古く `Concise` を挙げていないが、型は `string` なので検証は通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)