### PR TITLE
feat(claude): teammateMode を auto に変更する

### DIFF
--- a/dot_claude/settings.json.src
+++ b/dot_claude/settings.json.src
@@ -133,6 +133,6 @@
   "effortLevel": "high",
   "outputStyle": "Concise",
   "tui": "fullscreen",
-  "teammateMode": "tmux",
+  "teammateMode": "auto",
   "advisorModel": "opus"
 }


### PR DESCRIPTION
## 変更内容

`dot_claude/settings.json.src` の `teammateMode` を `tmux` から `auto` に変更する。

## 背景

`tmux` は split pane モードを常に有効にするため、tmux セッション外や
split pane 非対応の環境（VS Code 統合ターミナル、Windows Terminal、Ghostty）では
うまく動作しない。環境に応じて自動判定する `auto` に切り替える。

`auto` は tmux セッション内、または `it2` CLI 入りの iTerm2 のときのみ split pane を使い、
それ以外は in-process にフォールバックする。tmux 上で作業しているときは
これまでどおり split pane が使われる。

## 設定候補（ドキュメント確認済み）

[Choose a display mode](https://code.claude.com/docs/en/agent-teams#choose-a-display-mode) および
[JSON Schema](https://json.schemastore.org/claude-code-settings.json) より、`teammateMode` の候補は以下の4つ:

| 値 | 挙動 |
| --- | --- |
| `in-process` | 全 teammate をメインターミナル内で実行。デフォルト（v2.1.179 以降） |
| `auto` | tmux セッション内 / it2 入り iTerm2 なら split pane、それ以外は in-process |
| `tmux` | split pane を強制。tmux か iTerm2 かは自動判定（変更前の設定） |
| `iterm2` | iTerm2 ネイティブ split pane を強制。`it2` CLI が必須（v2.1.186 以降） |

## 確認事項

- `check-jsonschema` によるスキーマ検証をローカルで実行し `ok -- validation done` を確認
- `.github/scripts/check-shared-settings.sh` を実行し、環境依存の値の混入がないことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7ydhM9vro2LXEqkX5Zp8s)_