### PR TITLE
feat(lint): markdownlint-cli2 のバージョン固定箇所を1つに保つ

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -33,7 +33,10 @@ Markdownlintルールに準拠したドキュメント作成を推奨:
   aligned styleが文字幅の違いで破綻するため。`.markdownlint-cli2.yaml`で
   `style: compact`を明示している（既定の`consistent`はファイル内で揃っていれば
   aligned styleも通してしまう）。区切り行のダッシュ長（`| ------ |`）はMD060の
-  対象外で誰も検出しないが、表示上は無害なので許容する
+  対象外で誰も検出しないが、表示上は無害なので許容する。
+  MD060の挙動がバージョン依存になるため、markdownlint-cli2はバージョンを固定している。
+  固定箇所は`dot_config/shim-definitions`の1行だけで、CIもそこから抽出して使う
+  （[CLAUDE.md](../../CLAUDE.md)の「ツール管理方針」を参照）
 
   compact styleの例:
 

--- a/.github/scripts/check-repo-conventions.sh
+++ b/.github/scripts/check-repo-conventions.sh
@@ -110,6 +110,98 @@ check_shim_definitions() {
   done
 }
 
+# 規約3: markdownlint-cli2 のバージョンは dot_config/shim-definitions を単一情報源とする。
+#
+# `.markdownlint-cli2.yaml` で MD060 の style を明示しており、ルールの挙動が
+# バージョンに依存する。CIとローカルで版が食い違うと「ローカルで通ったのに
+# CIで落ちる」が起きる。固定箇所を2つ持って一致を検査するのではなく、
+# CI側が shim 定義から抽出することで、そもそもドリフトを起こしえなくする。
+#
+# その設計がなし崩しにされるのを防ぐため、次の3点を検査する:
+#   1. shim 定義でバージョンが固定されていること
+#   2. linter.yaml が markdownlint-cli2 のバージョンをハードコードしていないこと
+#      （「簡潔にしよう」と直書きに戻されると単一情報源が黙って崩れる）
+#   3. linter.yaml が shim 定義を参照していること
+MARKDOWNLINT_PKG="markdownlint-cli2"
+SHIM_DEFS_FILE="dot_config/shim-definitions"
+LINTER_WORKFLOW_FILE=".github/workflows/linter.yaml"
+
+# shim定義から `runner:<package>[@<version>][:alias]` を探す。
+# 出力: "<行番号> <バージョン>"。行が無ければ "0"、バージョン未固定なら "<行番号>" のみ
+find_shim_version() {
+  local pkg="$1" file="$2" line lineno rest
+  local -a lines=()
+  mapfile -t lines <"$file"
+  for lineno in "${!lines[@]}"; do
+    line=$(strip_cr "${lines[lineno]}")
+    [[ -z $line || $line == \#* ]] && continue
+    # runner を落として package 以降だけを見る
+    rest="${line#*:}"
+    if [[ $rest == "$pkg" || $rest == "$pkg:"* ]]; then
+      printf '%s\n' "$((lineno + 1))"
+      return 0
+    fi
+    if [[ $rest == "$pkg@"* ]]; then
+      rest="${rest#"$pkg@"}"
+      printf '%s %s\n' "$((lineno + 1))" "${rest%%:*}"
+      return 0
+    fi
+  done
+  printf '0\n'
+}
+
+check_markdownlint_version_source() {
+  local shim_lineno shim_ver line lineno rest
+  local refs_shim_defs=0 mentions_pkg=0 hardcoded_lineno=0
+  local -a lines=()
+
+  if [[ ! -f $SHIM_DEFS_FILE ]]; then
+    fail "$SHIM_DEFS_FILE" 0 "バージョンの単一情報源が無い"
+    return 0
+  fi
+
+  read -r shim_lineno shim_ver < <(find_shim_version "$MARKDOWNLINT_PKG" "$SHIM_DEFS_FILE" || true)
+  if [[ $shim_lineno -eq 0 ]]; then
+    fail "$SHIM_DEFS_FILE" 0 "$MARKDOWNLINT_PKG の shim 定義が無い。CIもここからバージョンを読むため、消すとCIが壊れる"
+  elif [[ -z $shim_ver ]]; then
+    fail "$SHIM_DEFS_FILE" "$shim_lineno" "$MARKDOWNLINT_PKG のバージョンが固定されていない（\`pnpm:$MARKDOWNLINT_PKG@<version>:$MARKDOWNLINT_PKG\` の形にすること）"
+  fi
+
+  if [[ ! -f $LINTER_WORKFLOW_FILE ]]; then
+    fail "$LINTER_WORKFLOW_FILE" 0 "$MARKDOWNLINT_PKG を実行するワークフローが無い"
+    return 0
+  fi
+
+  mapfile -t lines <"$LINTER_WORKFLOW_FILE"
+  for lineno in "${!lines[@]}"; do
+    line=$(strip_cr "${lines[lineno]}")
+    # コメント行は除外する。「shim定義から抽出する」と書いたコメントだけが残り、
+    # 実行される側は非固定インストールに戻っている、を通してしまうため
+    [[ $line =~ ^[[:space:]]*# ]] && continue
+    [[ $line == *"$SHIM_DEFS_FILE"* ]] && refs_shim_defs=1
+    [[ $line == *"$MARKDOWNLINT_PKG"* ]] || continue
+    mentions_pkg=1
+    # packageは正規表現ではなく文字列一致で切り出すため、`@`を含む
+    # scoped package を対象にしても壊れない
+    [[ $line == *"$MARKDOWNLINT_PKG@"* ]] || continue
+    rest="${line#*"$MARKDOWNLINT_PKG@"}"
+    # `@${version}` のような変数参照ではなく、数字で始まる直書きだけを拾う
+    [[ $rest =~ ^[0-9] ]] || continue
+    [[ $hardcoded_lineno -eq 0 ]] && hardcoded_lineno=$((lineno + 1))
+  done
+
+  if [[ $mentions_pkg -eq 0 ]]; then
+    fail "$LINTER_WORKFLOW_FILE" 0 "$MARKDOWNLINT_PKG への言及が無い。markdownlint ジョブが消えている"
+    return 0
+  fi
+  if [[ $hardcoded_lineno -ne 0 ]]; then
+    fail "$LINTER_WORKFLOW_FILE" "$hardcoded_lineno" "$MARKDOWNLINT_PKG のバージョンが直書きされている。$SHIM_DEFS_FILE から抽出すること（固定箇所を1つに保つ）"
+  fi
+  if [[ $refs_shim_defs -eq 0 ]]; then
+    fail "$LINTER_WORKFLOW_FILE" 0 "$SHIM_DEFS_FILE を参照していない。$MARKDOWNLINT_PKG のバージョンはそこから抽出すること（固定箇所を1つに保つ）"
+  fi
+}
+
 check_file() {
   local file="$1"
   if [[ ! -f $file ]]; then
@@ -130,13 +222,26 @@ collect_default_targets() {
     find . -name '*.tmpl' -not -path './.git/*'
 }
 
+# バージョンの単一情報源はファイル単位ではなくファイル間の不変条件なので、
+# 引数にどちらか一方でも含まれていれば両方を読んで検査する。
+version_source_requested() {
+  local file normalized
+  for file in "$@"; do
+    normalized="${file#./}"
+    [[ $normalized == "$SHIM_DEFS_FILE" || $normalized == "$LINTER_WORKFLOW_FILE" ]] && return 0
+  done
+  return 1
+}
+
 main() {
   local file
   if [[ $# -gt 0 ]]; then
     for file in "$@"; do
       check_file "$file"
     done
+    version_source_requested "$@" && check_markdownlint_version_source
   else
+    check_markdownlint_version_source
     local -a targets=()
     mapfile -t targets < <(collect_default_targets || true)
     for file in "${targets[@]}"; do

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -59,7 +59,18 @@ jobs:
         with:
           node-version: "22"
       - name: Install markdownlint-cli2
-        run: npm install -g markdownlint-cli2
+        # バージョンは dot_config/shim-definitions を単一情報源として抽出する。
+        # ここにハードコードするとローカルの pnpm shim と黙って乖離するため。
+        # この形を保っているかは .github/scripts/check-repo-conventions.sh が検査する
+        run: |
+          set -euo pipefail
+          version=$(sed -n 's/^pnpm:markdownlint-cli2@\(.*\):markdownlint-cli2$/\1/p' dot_config/shim-definitions)
+          if [ -z "$version" ]; then
+            echo "::error::dot_config/shim-definitions から markdownlint-cli2 のバージョンを抽出できなかった。定義の形式を確認すること。"
+            exit 1
+          fi
+          echo "markdownlint-cli2@${version} をインストールする"
+          npm install -g "markdownlint-cli2@${version}"
       - name: Run markdownlint-cli2 with reviewdog
         uses: reviewdog/action-setup@v1
       - name: markdownlint

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -71,6 +71,27 @@ jobs:
           fi
           echo "markdownlint-cli2@${version} をインストールする"
           npm install -g "markdownlint-cli2@${version}"
+
+          # 上の抽出が実際に効いたことを実行時に裏取りする。静的検査
+          # （check-repo-conventions.sh）は「早く落ちる」ための層で、
+          # 文字列一致でしか見ていないため抜け道が残りうる。ここは「必ず落ちる」層。
+          #
+          # `--version` はグロブとしても解釈されるため lint 出力が続く
+          # （例: `markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)`）。
+          # node の警告などが先に混ざりうるので、行位置は決め打ちせず全行から探す
+          version_output=$(markdownlint-cli2 --version 2>&1) || true
+          installed=$(printf '%s\n' "$version_output" |
+            sed -n 's/^markdownlint-cli2 v\([0-9][0-9A-Za-z.-]*\).*$/\1/p' | head -1)
+          if [ -z "$installed" ]; then
+            echo "::error::markdownlint-cli2 --version の出力を解釈できなかった。出力形式が変わった可能性がある。"
+            printf '%s\n' "$version_output"
+            exit 1
+          fi
+          if [ "$installed" != "$version" ]; then
+            echo "::error::インストールされた markdownlint-cli2 が ${installed} で、dot_config/shim-definitions の ${version} と一致しない。"
+            exit 1
+          fi
+          echo "markdownlint-cli2 ${installed} を確認した"
       - name: Run markdownlint-cli2 with reviewdog
         uses: reviewdog/action-setup@v1
       - name: markdownlint

--- a/.github/workflows/markdownlint-version-update.yaml
+++ b/.github/workflows/markdownlint-version-update.yaml
@@ -1,0 +1,204 @@
+---
+name: markdownlint-cli2 update
+
+on:
+  schedule:
+    - cron: "0 3 * * 4" # 毎週木曜 03:00 UTC (JST 12:00)。flake.lock 更新(月 09:00 UTC)と分ける
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: markdownlint-version-update
+  cancel-in-progress: false
+
+env:
+  # バージョンの単一情報源。CI の lint も `.github/workflows/linter.yaml` が
+  # ここから抽出して使うため、更新するのはこのファイルの1行だけでよい
+  SHIM_DEFS: dot_config/shim-definitions
+  BRANCH: chore/markdownlint-cli2-update
+  # リリース直後のバージョンには飛びつかない。`dot_npmrc` の
+  # `minimum-release-age=4320`（分。3日）と同じ趣旨の設定が別に存在するが、
+  # あちらは pnpm 専用で `npm install -g` には効かない（npm は Unknown user
+  # config として無視する）。単位も違うので一元化はせず、二重に持つ
+  MIN_RELEASE_AGE_DAYS: "3"
+
+jobs:
+  update:
+    name: Check for new markdownlint-cli2 and verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Resolve target version
+        id: resolve
+        run: |
+          set -euo pipefail
+
+          CURRENT=$(sed -n 's/^pnpm:markdownlint-cli2@\([^:]*\):.*$/\1/p' "$SHIM_DEFS")
+          # 後段で正規表現に埋め込むため、ここで形を確定させておく
+          if ! printf '%s' "$CURRENT" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::$SHIM_DEFS から現在のバージョンを読み取れなかった（取得値: '${CURRENT}'）。定義の形式が変わった可能性がある。"
+            exit 1
+          fi
+
+          # 公開から MIN_RELEASE_AGE_DAYS 日以上経った安定版だけを候補にする
+          CUTOFF=$(date -u -d "${MIN_RELEASE_AGE_DAYS} days ago" +%Y-%m-%dT%H:%M:%S.000Z)
+          TARGET=$(npm view markdownlint-cli2 time --json | jq -r --arg cutoff "$CUTOFF" '
+            to_entries
+            | map(select(.key | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")))
+            | map(select(.value <= $cutoff))
+            | .[].key
+          ' | sort -V | tail -1)
+
+          if [ -z "$TARGET" ]; then
+            echo "::error::候補バージョンを1つも取得できなかった。npm registry の応答を確認すること。"
+            exit 1
+          fi
+
+          echo "current=$CURRENT / target=$TARGET (cutoff=$CUTOFF)"
+
+          NEWEST=$(printf '%s\n%s\n' "$CURRENT" "$TARGET" | sort -V | tail -1)
+          if [ "$TARGET" = "$CURRENT" ] || [ "$NEWEST" != "$TARGET" ]; then
+            echo "更新なし（固定中の $CURRENT が候補 $TARGET 以上）"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "changed=true"
+            echo "current=$CURRENT"
+            echo "target=$TARGET"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Bump the pinned version
+        if: steps.resolve.outputs.changed == 'true'
+        env:
+          CURRENT: ${{ steps.resolve.outputs.current }}
+          TARGET: ${{ steps.resolve.outputs.target }}
+        run: |
+          set -euo pipefail
+
+          # `.` をエスケープする。素で置くと `0.23.2` が `0x23y2` のような
+          # 文字列にもマッチする。CURRENT は resolve ステップで
+          # `<数字>.<数字>.<数字>` に限定済みなので、対象は `.` だけでよい
+          CURRENT_RE=${CURRENT//./\\.}
+          sed -i "s|^pnpm:markdownlint-cli2@${CURRENT_RE}:|pnpm:markdownlint-cli2@${TARGET}:|" "$SHIM_DEFS"
+
+          if git diff --quiet -- "$SHIM_DEFS"; then
+            echo "::error::$SHIM_DEFS を書き換えられなかった。定義の記述形式が変わった可能性がある。"
+            exit 1
+          fi
+
+          # 単一情報源の形が保たれていることを既存のチェッカーで確認する
+          .github/scripts/check-repo-conventions.sh
+
+      - name: Commit to update branch
+        if: steps.resolve.outputs.changed == 'true'
+        env:
+          TARGET: ${{ steps.resolve.outputs.target }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add "$SHIM_DEFS"
+          git commit -m "chore(lint): markdownlint-cli2 を ${TARGET} に更新"
+
+      # この仕組みの中核。新バージョンで既存の .md が全部通るかを実際に確かめる。
+      # GITHUB_TOKEN が作成した PR では workflow がトリガーされないため、
+      # 検証はこのワークフロー内で実施し結果を PR 本文に残す
+      - name: Verify all Markdown passes with the new version
+        id: verify
+        if: steps.resolve.outputs.changed == 'true'
+        continue-on-error: true
+        env:
+          TARGET: ${{ steps.resolve.outputs.target }}
+        run: |
+          set -euo pipefail
+          npm install -g "markdownlint-cli2@${TARGET}"
+          markdownlint-cli2 "**/*.md" 2>&1 | tee /tmp/markdownlint-output.txt
+
+      - name: Create or update pull request
+        if: steps.resolve.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT: ${{ steps.resolve.outputs.current }}
+          TARGET: ${{ steps.resolve.outputs.target }}
+          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          set -euo pipefail
+
+          # 追跡ブランチが無い状態で --force-with-lease を使うと fatal になるため、
+          # リモートに既存ブランチがある場合のみ lease を付ける
+          if git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"; then
+            git push origin "$BRANCH" --force-with-lease
+          else
+            git push origin "$BRANCH"
+          fi
+
+          if [ "$VERIFY_OUTCOME" = "success" ]; then
+            VERIFY_LINE="✅ 全 Markdown が \`markdownlint-cli2@${TARGET}\` で通った"
+          else
+            VERIFY_LINE="❌ \`markdownlint-cli2@${TARGET}\` で指摘が出た — **マージしないこと**"
+          fi
+
+          {
+            echo "## markdownlint-cli2 週次更新"
+            echo
+            echo "- \`${CURRENT}\` → \`${TARGET}\`（公開から ${MIN_RELEASE_AGE_DAYS} 日以上経過した安定版のみ候補）"
+            echo "- 検証: ${VERIFY_LINE}"
+            echo "- 実行ログ: ${RUN_URL}"
+            echo
+            echo "### 更新箇所"
+            echo
+            echo "- \`${SHIM_DEFS}\` の1行のみ。CI の lint もここから抽出して使う"
+            echo
+            echo "### lint 結果"
+            echo
+            echo '```'
+            cat /tmp/markdownlint-output.txt 2>/dev/null || echo "(検証ステップが出力を残さなかった)"
+            echo '```'
+            echo
+            echo "### 補足"
+            echo
+            echo "\`GITHUB_TOKEN\` で作成した PR では CI が自動で走らないことがある。"
+            echo "lint の検証は上記の実行ログ内で実施済み。"
+            echo
+            echo "### ローカルでの確認手順"
+            echo
+            echo '```bash'
+            echo "git fetch origin ${BRANCH} && git switch ${BRANCH}"
+            echo "chezmoi apply ~/.config/shim-definitions ~/.scripts"
+            echo "markdownlint-cli2 \"**/*.md\""
+            echo '```'
+          } > /tmp/pr-body.md
+
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""')
+
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --body-file /tmp/pr-body.md
+            gh pr comment "$EXISTING" --body "markdownlint-cli2 を \`${TARGET}\` に更新し直した（検証: ${VERIFY_OUTCOME}）。"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(lint): markdownlint-cli2 を ${TARGET} に更新" \
+              --body-file /tmp/pr-body.md \
+              --label "dependencies" \
+              --label "automated"
+          fi
+
+      - name: Fail if lint verification failed
+        if: steps.resolve.outputs.changed == 'true' && steps.verify.outcome == 'failure'
+        run: |
+          echo "::error::新しい markdownlint-cli2 で既存の Markdown が通らなかった。PR はマージせず調査すること。"
+          exit 1

--- a/.github/workflows/repo-conventions.yaml
+++ b/.github/workflows/repo-conventions.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - "**/*.tmpl"
       - "dot_config/shim-definitions"
+      # バージョン同期チェックの対象。linter.yaml だけを書き換えたPRでも走らせる
+      - ".github/workflows/linter.yaml"
       - ".github/scripts/check-repo-conventions.sh"
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         description: chezmoiテンプレート・shim定義の機械的に判定できる規約を検査する
         entry: .github/scripts/check-repo-conventions.sh
         language: script
-        files: (\.tmpl|dot_config/shim-definitions)$
+        files: (\.tmpl|dot_config/shim-definitions|\.github/workflows/linter\.yaml)$
         pass_filenames: true
       # コミット前に必ず通る唯一の層。PostToolUseフックは編集手段に依存し
       # （Bash経由の編集では発火しない）、CIはPRを作るまで走らないため、

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,12 @@ Ubuntu/WSL2環境向けのChezmoiで管理された個人用dotfilesリポジト
 - **winget**（Windows）: Nix CLIツールのWindows対応版 + Windows専用アプリ
 - **uvx/pnpm shim**（`dot_config/shim-definitions`）: `chezmoi apply`時に`~/.scripts/`へラッパースクリプトを自動生成。新ツール追加は定義ファイルに1行追加するだけ
 - 判定基準: CLIツール→Nix、ビルド依存→APT、PJごとのバージョン固定が必要→mise、root権限必要→APT、Pythonツール(ruff等)→uvx shim、JSツール(markdownlint-cli2等)→pnpm shim
+- markdownlint-cli2 だけはバージョンを固定する（現在 `0.23.2`）。`.markdownlint-cli2.yaml`で
+  MD060の`style`を明示しており、ルールの挙動がバージョンに依存するため、CIとローカルで
+  版が食い違うと「ローカルで通ったのにCIで落ちる」が起きる。
+  **固定箇所は`dot_config/shim-definitions`の1行だけ**。CI（`.github/workflows/linter.yaml`）は
+  そこからバージョンを抽出して`npm install -g`する。更新時に直すのはこの1箇所で、
+  乖離を検出する仕組みではなく乖離が起こりえない形にしてある
 - Nixはグローバルに1バージョンしか置けないため、PJごとに異なるバージョンを使い分けるツール（terraform等）はNixではなくmiseで管理する。
   ただしグローバルの`~/.config/mise/config.toml`ではなく、各プロジェクトの`mise.toml`に書く
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ GitHub Actionsで上記に加え、JSON Schema検証、E2Eテスト（Ubuntu/Win
 | テーブルはcompact style（最小パディング）。CJK文字幅でaligned styleが崩れるため | markdownlint MD060（`style: compact`） |
 | 先頭に条件分岐を置く`.tmpl`で、その直後がshebangならtrim marker（`-}}`）必須 | `.github/scripts/check-repo-conventions.sh` |
 | shim定義は`runner:package[:alias]`形式、`@`を含むpackageはalias必須 | 同上 |
+| markdownlint-cli2のバージョンはshim定義が単一情報源。CIが直書きに戻していないこと | 同上 |
 | 共有設定（`dot_claude/*.src`）にマシン固有・組織固有の値を入れない | `.github/scripts/check-shared-settings.sh` |
 | シェルスクリプトの品質（`[[ ]]`推奨、クォート漏れ等） | shellcheck（`.shellcheckrc`で`enable=all`）。**`.tmpl`は対象外** |
 

--- a/dot_config/shim-definitions
+++ b/dot_config/shim-definitions
@@ -14,7 +14,7 @@ uvx:mypy
 uvx:ty
 
 # JS/TS tools (pnpm dlx)
-pnpm:markdownlint-cli2
+pnpm:markdownlint-cli2@0.23.2:markdownlint-cli2
 pnpm:ccmanager
 pnpm:ccusage
 pnpm:@biomejs/biome:biome

--- a/dot_npmrc
+++ b/dot_npmrc
@@ -1,2 +1,5 @@
 # Minimum package release age before installation (minutes). 4320 = 3 days (supply chain attack mitigation)
+# NOTE: this is a pnpm setting. npm reads this file too but ignores the key
+# ("Unknown user config"), so CI's `npm install -g` is NOT covered by it.
+# .github/workflows/markdownlint-version-update.yaml checks publish age itself.
 minimum-release-age=4320


### PR DESCRIPTION
## 目的

markdownlint-cli2 のバージョンがローカル（pnpm shim）と CI（`npm install -g`）のどちらでも固定されておらず、乖離しうる状態だった。先日 `MD060: style: compact` を明示設定したことで MD060 の挙動がバージョン依存になり、この乖離の影響が以前より大きくなっていた。

固定するだけでなく、**固定箇所を1つに保つこと自体を機械的に担保する**ところまでを範囲とする。

## 変更内容

### 1. shim 定義を単一情報源にする

`dot_config/shim-definitions` の1行で固定する。既存の `runner:package[:alias]` 形式に乗るため新しい仕組みは要らない。

```
pnpm:markdownlint-cli2@0.23.2:markdownlint-cli2
```

`@` を含む package は alias 必須という既存の規約（`check-repo-conventions.sh` が検出する）にちょうど適合する。

生成される shim が実際に固定バージョンを起動することは、live な `~/` を汚さない fake HOME で実測した:

- 生成物: `exec pnpm dlx "markdownlint-cli2@0.23.2" "$@"`
- 実行: `markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)`
- 対照実験として `pnpm dlx "markdownlint-cli2@0.22.1" --version` → `v0.22.1` を確認。バージョン文字列が素通りではなく実際に解決に使われている

CI 側は `.github/workflows/linter.yaml` にバージョンを書かず、shim 定義から抽出する。抽出に失敗したら `::error::` で明示的に落とす（空文字のまま `npm install -g markdownlint-cli2@` に流れて曖昧に失敗する形にしない）。

**バージョンを書き換える箇所は shim 定義の1行だけ**になり、同期ずれが原理的に発生しなくなる。

固定バージョンの 0.23.2 は現時点の npm latest で、ローカル・CI とも既にこれを引いている。つまりこの固定は挙動上 no-op で、既存の Markdown が新たに落ちるリスクはない。

### 2. 単一情報源が崩れることを静的に検出する

`.github/scripts/check-repo-conventions.sh` に3点の検査を追加した。

- shim 定義で markdownlint-cli2 がバージョン固定されていること
- `linter.yaml` にバージョンが直書きされていないこと
- `linter.yaml` が shim 定義を参照していること

3つ目が無いと、誰かが「簡潔にしよう」と直書きに戻したときに単一情報源が黙って崩れる。

トリガ経路の穴も塞いだ。`.github/workflows/repo-conventions.yaml` の `paths` と `.pre-commit-config.yaml` の `files` に `linter.yaml` が入っていなかったため、`linter.yaml` 単独の変更ではこの検査が走らなかった。

### 3. インストールされたバージョンを実行時に検証する

静的検査は文字列一致でしか見ておらず、「抽出結果を実際に `npm install` に渡しているか」は原理的に証明できない。CI で実際に入ったバージョンを `markdownlint-cli2 --version` から読み取り、shim 定義の値と一致しなければ落とす。

静的検査が「早く落ちる」層（prek でコミット前に落ちる）、実行時アサーションが「必ず落ちる」層、という二重化。

出力形式を解釈できなかった場合も fail させる。`installed` が空なら比較に到達せず先に落ちるので、「空文字同士が一致して pass」は構造的に起きない。

### 4. 新バージョンを定期検出して検証するワークフロー

`.github/workflows/markdownlint-version-update.yaml`（新規）。既存の `flake-lock-update.yaml` と同じ骨格 — スケジュール実行、固定ブランチへの force push、既存 PR があれば更新、`dependencies` / `automated` ラベル。

**検証が中核**で、新バージョンをインストールして `markdownlint-cli2 "**/*.md"` が全ファイル通るかを確認する。通らなければ PR 本文に「マージしないこと」と明記し job も fail させる（flake-lock 版と同じ扱い）。

書き換えるのは `dot_config/shim-definitions` の1行のみ。

## 実装中に見つけた問題

### 自分の検査に穴があった（修正済み）

「`linter.yaml` が shim 定義を参照しているか」の検査が行単位の文字列一致だったため、**説明のために書いたコメント自体がその検査を満たしてしまっていた**。コメントを残したまま非固定インストールに戻すと素通りする状態だった。

```yaml
- name: Install markdownlint-cli2
  # バージョンは dot_config/shim-definitions を単一情報源として抽出する。
  run: npm install -g markdownlint-cli2      # ← これが exit=0 で通っていた
```

最初のテストがステップ全体を差し替えていたため、参照検査が落ちたのは「抽出を見抜いたから」ではなく「コメントが消えたから」だった。検査しているつもりで、実際にはコメントの有無を見ていただけ。

コメント行を走査対象外にして修正。これで3つの検査すべてが「実行される内容」だけを見る。

### `minimum-release-age` は npm では効かない

`dot_npmrc` の `minimum-release-age=4320`（3日、サプライチェーン対策）は **pnpm の設定で npm は認識しない**（`npm warn Unknown user config` が出る）。つまり CI の `npm install -g` には元々この保護が掛かっていなかった。

定期更新ワークフロー側では npm registry の publish 時刻を見て、3日未満のバージョンをスキップする。両方のコメントに、もう一方が別に存在することと効く対象が違うことを明記した。単位も対象も違うので一元化はしない。

### bump 用 sed のエスケープが壊れていた

バージョン文字列の `.` をエスケープする sed が、`/` と区切り文字の衝突で `unterminated 's' command` になっていた。resolve ステップで semver を検証したうえで bash のパラメータ展開に置き換えた。

## 設計判断

**mise での固定は採らない。** CLAUDE.md のツール管理方針が「JSツール→pnpm shim」と明記しており、mise に寄せると方針そのものの変更になって課題に対して過大。

**Renovate も採らない。** バージョンが独自形式のファイルにあり `customManagers` の正規表現が必要で「標準ツールだから楽」という利点が消える。public リポジトリに GitHub App の書き込み権限を追加することにもなる。また検証ステップが中核だが、このリポジトリ自身が注記しているとおり `GITHUB_TOKEN` 由来の PR には CI が走らない。

**ボットが `linter.yaml` を書き換える設計は成立しない。** `GITHUB_TOKEN` はワークフローファイルを push できず、`workflows` は `permissions:` に書けるスコープに存在しない（`actionlint` で確認）。PAT / GitHub App のスコープにしかない。これが単一情報源に倒した直接の理由。

## 検証

`prek run --all-files` 全 Passed、`actionlint` Passed。3コミットそれぞれを `git archive` で取り出して規約チェックを実行し、途中のコミットでも壊れていないことを確認。

「わざと壊す」テストは全ケース exit=1 を実測（shim のバージョンが外れた / shim 定義の行ごと消えた / linter.yaml から記述が消えた / 直書きに戻された / 別経路に書き換えられた / コメントだけ残して非固定に戻された）。偽陽性側も確認（無関係なファイルのみを引数に渡した場合はスキップ、CI に対応記述の無い `@version` 付きツールを足しても落ちない）。

実行時アサーションは7ケース。実物との一致 / 不一致、バナー無し、無出力、exit 127、先頭に node の警告が混ざるケース（通るべき）、警告混入かつ別バージョン（落ちるべき）。

## 未検証

ランナー上での実行は確認できていない。

- `linter.yaml` の抽出ステップと実行時アサーションが GitHub Actions 上で動くこと（シェルロジックはローカルで確認済み）
- 定期更新ワークフローの `git push` が通ること。ワークフローファイルを触らなくなったので通るはずだが、これは推論
- `gh pr create` / `gh pr edit` / ラベル付与
- cron の発火

🤖 Generated with [Claude Code](https://claude.com/claude-code)
