### PR TITLE
fix(chezmoi): 設定ファイルが無いマシンで apply が失敗するのを直す

### DIFF
--- a/.claude/rules/chezmoi.md
+++ b/.claude/rules/chezmoi.md
@@ -22,6 +22,14 @@ description: Chezmoi設定管理ガイドライン
 - `run_after_`スクリプトで条件分岐（`{{ if ... }}`）をshebang行の前に置く場合、
   trim marker（`{{ if ... -}}`）を使うこと。そうしないとshebangが2行目になり実行に失敗する
   （`.github/scripts/check-repo-conventions.sh`が検出する）
+- chezmoiは`missingkey=error`でテンプレートを実行する。`~/.config/chezmoi/chezmoi.toml`
+  由来のキー（`.chezmoi.requireGUI`等）を直接参照すると、そのキーを設定していない
+  マシンで`chezmoi apply`全体が失敗する。`dig "requireGUI" true .chezmoi`のように
+  既定値付きで読み、設定ファイルが無くても成立する形にすること。
+  開発機にはconfigがあるので手元では気づけないため、
+  `.github/scripts/check-repo-conventions.sh`がconfigを持たない状態で
+  `chezmoi archive`して検査する（見えるのは実行OSで展開対象になる
+  テンプレートの通過した分岐だけ。詳細はCLAUDE.mdの「検査されない範囲」）
 
 ## shim管理（uvx/pnpm ラッパースクリプト）
 

--- a/.github/scripts/check-repo-conventions.sh
+++ b/.github/scripts/check-repo-conventions.sh
@@ -209,6 +209,55 @@ check_markdownlint_version_source() {
   fi
 }
 
+# 規約4: chezmoiのソースディレクトリは、設定ファイルが無い環境でもレンダリングできること。
+#
+# chezmoiはテンプレートを`missingkey=error`で実行するため、
+# `~/.config/chezmoi/chezmoi.toml`にしか無いキー（`.chezmoi.requireGUI`等）を
+# 直接参照すると、そのキーを書いていないマシンで`chezmoi apply`全体が失敗する。
+# 開発機にはconfigがあるので手元では気づけない（#216はこれで長く残った）。
+#
+# 「非組み込みのキーを直接参照していないか」を文字列で判定しようとすると、
+# 組み込み変数のホワイトリスト維持とコメント内の誤検知がついて回る。
+# configを持たない状態で実際にレンダリングすれば、判定はchezmoi自身が行う。
+# キー以外の失敗（`include`先の欠落、テンプレート構文エラー）も同時に捕まる。
+#
+# レンダリングには`archive`（tarを作って捨てるだけ）を使う。`apply --dry-run`でも
+# 同じ判定になるが、あちらは宛先の指定や`--dry-run`の付け忘れが事故になりうる。
+#
+# 守備範囲は「実行しているOSでレンダリング対象になるテンプレートの、通過した分岐」だけ。
+# `.chezmoiignore`が除外するものと通らなかった分岐は見ない
+# （CLAUDE.mdの「検査されない範囲」を参照）。
+check_templates_render_without_config() {
+  local chezmoi_bin root config_dir output
+  if ! chezmoi_bin=$(command -v chezmoi); then
+    # 黙ってスキップすると「検査したつもり」の素通りになるので、この検査を
+    # 担保する呼び出し側（repo-conventions.yaml）は REQUIRE_CHEZMOI=1 を立てる。
+    # 「CIなら落とす」にすると、バージョン検査だけを目的に同じスクリプトを呼ぶ
+    # markdownlint-version-update.yaml まで巻き込む
+    if [[ -n ${REQUIRE_CHEZMOI:-} ]]; then
+      fail "(chezmoi templates)" 0 "chezmoi が見つからない。この検査はレンダリングを実行するので chezmoi が必須"
+      return 0
+    fi
+    printf '注意: chezmoi が無いため「configなしでのレンダリング」検査をスキップした（REQUIRE_CHEZMOI=1 なら落とす）\n' >&2
+    return 0
+  fi
+  if ! root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    root="$PWD"
+  fi
+  # 実マシンのconfigを確実に無視するため、存在しないパスを渡す
+  if ! config_dir=$(mktemp -d); then
+    fail "(chezmoi templates)" 0 "一時ディレクトリを作れない"
+    return 0
+  fi
+
+  if ! output=$("$chezmoi_bin" archive --source "$root" \
+    --config "$config_dir/absent.toml" --output /dev/null 2>&1); then
+    printf '%s\n' "$output" >&2
+    fail "(chezmoi templates)" 0 "設定ファイルが無い環境でレンダリングに失敗する（原因は直前のエラー）。マシン固有のキーが原因なら \`dig \"key\" <既定値> .chezmoi\` のように既定値付きで読むこと"
+  fi
+  rm -rf "$config_dir"
+}
+
 check_file() {
   local file="$1"
   if [[ ! -f $file ]]; then
@@ -247,8 +296,12 @@ main() {
       check_file "$file"
     done
     version_source_requested "$@" && check_markdownlint_version_source
+    # ソースディレクトリ全体の不変条件で、どのファイルが渡ったかに依らない。
+    # 呼び出し側（prek/CI）のパターンと同期させると穴が空くので、常に検査する
+    check_templates_render_without_config
   else
     check_markdownlint_version_source
+    check_templates_render_without_config
     local -a targets=()
     mapfile -t targets < <(collect_default_targets || true)
     for file in "${targets[@]}"; do

--- a/.github/workflows/e2e-test-ubuntu.yaml
+++ b/.github/workflows/e2e-test-ubuntu.yaml
@@ -26,12 +26,10 @@ jobs:
           mkdir -p "$HOME/.local/share"
           ln -s "$GITHUB_WORKSPACE" "$HOME/.local/share/chezmoi"
 
-          # Create chezmoi config with required template variables
-          mkdir -p "$HOME/.config/chezmoi"
-          cat > "$HOME/.config/chezmoi/chezmoi.toml" << 'EOF'
-          [data.chezmoi]
-            requireGUI = false
-          EOF
+          # chezmoi の設定ファイルは意図的に作らない。
+          # `~/.config/chezmoi/chezmoi.toml` に requireGUI を書いていない実マシンを
+          # 再現するため（#216 の回帰テスト）。ここで config を書くと、
+          # テンプレートが未定義キーを直接参照して落ちる状態を CI が見逃す。
 
           # Apply dotfiles (skip heavy setup scripts)
           "$HOME/.local/bin/chezmoi" apply --exclude scripts --force
@@ -74,6 +72,39 @@ jobs:
             exit 0
           else
             echo "$errors file(s) missing"
+            exit 1
+          fi
+
+      - name: Verify requireGUI handling
+        run: |
+          set -euo pipefail
+          chezmoi="$HOME/.local/bin/chezmoi"
+          launcher="$HOME/once_setup_ubuntu.sh"
+
+          # 設定ファイルを作っていない = requireGUI 未定義。#216 の回帰テスト。
+          # レンダリングが通り、非WSLの既定 true になること
+          echo "=== without chezmoi config ==="
+          if grep -qx 'REQUIRE_GUI=true' "$launcher"; then
+            echo "[OK] renders without the key, defaults to REQUIRE_GUI=true"
+          else
+            echo "[ERROR] unexpected rendering without config"
+            grep -n 'REQUIRE_GUI' "$launcher" || true
+            exit 1
+          fi
+
+          # 明示値が既定に勝つこと。config がある状態の apply 経路もここで通す
+          echo "=== with requireGUI = false ==="
+          mkdir -p "$HOME/.config/chezmoi"
+          cat > "$HOME/.config/chezmoi/chezmoi.toml" << 'EOF'
+          [data.chezmoi]
+            requireGUI = false
+          EOF
+          "$chezmoi" apply --exclude scripts --force
+          if grep -qx 'REQUIRE_GUI=false' "$launcher"; then
+            echo "[OK] the explicit value overrides the default"
+          else
+            echo "[ERROR] requireGUI = false was not honored"
+            grep -n 'REQUIRE_GUI' "$launcher" || true
             exit 1
           fi
 

--- a/.github/workflows/repo-conventions.yaml
+++ b/.github/workflows/repo-conventions.yaml
@@ -5,6 +5,12 @@ on:
   pull_request:
     paths:
       - "**/*.tmpl"
+      # 規約4（configなしでレンダリングできる）はソース全体の不変条件。
+      # レンダリング結果に影響するファイルも対象にする
+      - ".chezmoiignore"
+      - ".chezmoiremove"
+      - "scripts/**"
+      - "dot_config/herdr-plugins"
       - "dot_config/shim-definitions"
       # バージョン同期チェックの対象。linter.yaml だけを書き換えたPRでも走らせる
       - ".github/workflows/linter.yaml"
@@ -18,5 +24,19 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+      # 「設定ファイルが無い環境で全テンプレートがレンダリングできるか」の検査に使う。
+      # ローカルでは Nix 経由の chezmoi が使われる
+      - name: Install chezmoi
+        run: |
+          set -euo pipefail
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # curl が失敗しても `sh -c ""` は exit 0 になる。入っていることを裏取りしないと
+          # 検査が無言でスキップされたままジョブが緑になる
+          "$HOME/.local/bin/chezmoi" --version
       - name: Check chezmoi/shim conventions
         run: .github/scripts/check-repo-conventions.sh
+        env:
+          # 規約4のレンダリング検査を担保するジョブ。chezmoi が無ければ
+          # スキップではなく失敗させる
+          REQUIRE_CHEZMOI: "1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,13 @@ repos:
         pass_filenames: true
       - id: repo-conventions
         name: repo conventions
+        # 規約4（configなしでレンダリングできる）はソース全体の不変条件なので、
+        # レンダリング結果に影響するファイル（本体スクリプト、include対象、
+        # `.chezmoiignore`）も起動対象に含める
         description: chezmoiテンプレート・shim定義の機械的に判定できる規約を検査する
         entry: .github/scripts/check-repo-conventions.sh
         language: script
-        files: (\.tmpl|dot_config/shim-definitions|\.github/workflows/linter\.yaml)$
+        files: (\.tmpl|\.chezmoiignore|\.chezmoiremove|^scripts/.*\.sh|dot_config/(shim-definitions|herdr-plugins)|\.github/workflows/linter\.yaml)$
         pass_filenames: true
       # コミット前に必ず通る唯一の層。PostToolUseフックは編集手段に依存し
       # （Bash経由の編集では発火しない）、CIはPRを作るまで走らないため、

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,14 @@ Ubuntu/WSL2環境向けのChezmoiで管理された個人用dotfilesリポジト
 - `~/.config/local/git_user_config` - Gitユーザー情報
 - `~/.config/local/tmux_repo_names` - tmuxタイトル用リポジトリ短縮名
 
+テンプレートが読む値（現状は`requireGUI`のみ）だけは例外で、`~/.config/chezmoi/chezmoi.toml`に
+置く。`~/.config/local/`はシェルから読むだけの場所で、chezmoiのテンプレートは自身のconfigしか
+データ源にできないため。テンプレート側は既定値付きで読むので、このファイルが無くても動く。
+
+`[data.chezmoi]`はchezmoiの予約名前空間に相乗りしており、`os`や`sourceDir`のような組み込みキーを
+警告なしに上書きできてしまう。既存マシンの設定を壊さないため移設していないが、キー名は
+組み込みと衝突しないものにすること。
+
 ## 開発コマンド
 
 ```bash
@@ -102,6 +110,7 @@ GitHub Actionsで上記に加え、JSON Schema検証、E2Eテスト（Ubuntu/Win
 | テーブルはcompact style（最小パディング）。CJK文字幅でaligned styleが崩れるため | markdownlint MD060（`style: compact`） |
 | 先頭に条件分岐を置く`.tmpl`で、その後（空行を挟んでもよい）がshebangならtrim marker（`-}}`）必須 | `.github/scripts/check-repo-conventions.sh` |
 | shim定義は`runner:package[:alias]`形式、`@`を含むpackageはalias必須 | 同上 |
+| `.tmpl`はchezmoiの設定ファイルが無い環境でもレンダリングできる（マシン固有のキーは`dig`等で既定値付きに読む） | 同上（configを持たない状態で`chezmoi archive`する） |
 | markdownlint-cli2のバージョンはshim定義が単一情報源。CIが直書きに戻していないこと | 同上 |
 | 共有設定（`dot_claude/*.src`）にマシン固有・組織固有の値を入れない | `.github/scripts/check-shared-settings.sh` |
 | シェルスクリプトの品質（`[[ ]]`推奨、クォート漏れ等） | shellcheck（`.shellcheckrc`で`enable=all`） |
@@ -116,6 +125,14 @@ GitHub Actionsで上記に加え、JSON Schema検証、E2Eテスト（Ubuntu/Win
   シェルコードはランチャー3本の計6行だけで、その失敗モード（shebangが1行目に
   来ない）は`check-repo-conventions.sh`の規約1が検出する
 - テーブル区切り行のダッシュ長（`| ------ |`）はMD060の対象外。表示上無害なので許容する
+- **規約4のレンダリング検査が見るのは「実行しているOSでレンダリング対象になる
+  テンプレートの、通過した分岐」だけ**。`.chezmoiignore`が除外するもの（Linuxで走らせた
+  ときの`dot_config/powershell/`等）と、`{{ if eq .chezmoi.os "windows" }}`の中は見ない。
+  Windows側は`e2e-test-windows.yaml`がconfigを作らずにapplyすることで結果的にカバーしている。
+  また組み込みキー（`.chezmoi.kernel`等）の直接参照は、通常のマシンには値があるため検出できない。
+  CIのchezmoiは版を固定していない（ローカルはNix版）ので、テンプレート解釈の
+  バージョン依存な変化は乖離しうる。`.chezmoiremove`はテンプレートとして評価するが、
+  「何が消えるか」は見ない
 
 ## `.tmpl`ランチャーと本体スクリプトの分離
 
@@ -139,10 +156,6 @@ PostToolUseフックがそのまま効くため、テンプレート用の検査
 - 素の`.sh`を`#!/bin/sh`で書く場合は先頭に`# shellcheck shell=sh`を置く。
   `.shellcheckrc`の`shell=bash`がshebangを上書きするため、付けないと
   bash前提の指摘（SC2292等）が誤って出る
-- テンプレート側の条件式は現状の短絡評価を壊さないこと。
-  `executable_once_setup_ubuntu.sh.tmpl`の`REQUIRE_GUI`は
-  `and`の短絡で`.chezmoi.requireGUI`に触れずに済ませている。無条件に評価する形へ
-  変えると、このキーを設定していないマシンでレンダリングが失敗する
 
 ## 詳細ガイドライン
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Bash と Zsh に対応。
 # 一時的に使うchezmoiをインストールする
 sh -c "$(curl -fsLS get.chezmoi.io)"
 # このリポジトリを所定ディレクトリにクローンし適用
+# GUIが不要なマシンは apply の前に requireGUI を設定する（後述）
 ${HOME}/bin/chezmoi init https://github.com/ebal5/dotfiles-chezmoi.git
 ${HOME}/bin/chezmoi apply
 # 初期スクリプトを起動する
@@ -29,6 +30,25 @@ ${HOME}/once_setup_ubuntu.sh
 # 初期に使用したchezmoiを削除しNixでインストールしたものを利用するようにする
 rm ~/bin/chezmoi
 ```
+
+#### GUIが不要なマシンの場合（requireGUI）
+
+`once_setup_ubuntu.sh` は非WSLのLinuxを既定でGUI機とみなし、日本語フォント
+（`fonts-migmix`、`fonts-ipafont-*`）を導入する。ヘッドレスなサーバなどで不要なら、
+`chezmoi apply` の**前に** `~/.config/chezmoi/chezmoi.toml` で上書きする。
+
+```toml
+[data.chezmoi]
+  requireGUI = false
+```
+
+この値は `chezmoi apply` の時点で `~/once_setup_ubuntu.sh` に焼き込まれるため、
+後から変える場合は toml を編集してから `chezmoi apply` をやり直す
+（設定していないマシンでも既定値で動く。ファイル自体が無くてもよい）。
+既にインストールしたフォントは apply をやり直しても消えない。
+
+値は TOML の真偽値で書くこと。`"false"` のような文字列や別のセクションに
+書いた場合は「設定されていない」とみなされ、既定値の true になる。
 
 ## install 後の作業
 

--- a/executable_once_setup_ubuntu.sh.tmpl
+++ b/executable_once_setup_ubuntu.sh.tmpl
@@ -1,14 +1,18 @@
 #!/bin/bash
-{{ if and (eq .chezmoi.os "linux") (eq .chezmoi.osRelease.id "ubuntu") }}
+{{ if and (eq .chezmoi.os "linux") (eq (dig "id" "" .chezmoi.osRelease) "ubuntu") }}
 # ランチャー。本体は `scripts/setup-ubuntu.sh`。
 # テンプレート構文を含むとshfmt/shellcheckがパースできないため、シェルコードは
 # 素の `.sh` に置いて既存のlintゲートに乗せ、ここには分岐だけを残す。
 #
-# REQUIRE_GUI は「非WSL かつ GUI が必要」を意味する。この条件式は現状のまま
-# 維持すること。`and` は短絡評価なので、WSL環境では `.chezmoi.requireGUI` に
-# 触れずに済む。無条件に評価する形に変えると、このキーを設定していないマシンで
-# レンダリングが失敗する。
-REQUIRE_GUI={{ if and (not (.chezmoi.kernel.osrelease | lower | contains "microsoft")) (.chezmoi.requireGUI) }}true{{ else }}false{{ end }}
+# REQUIRE_GUI は「非WSL かつ GUI が必要」を意味する。非WSLのLinuxは既定でGUI機と
+# みなし、日本語フォントを入れる。不要なら `~/.config/chezmoi/chezmoi.toml` に
+# `[data.chezmoi] requireGUI = false` を書いて `chezmoi apply` し直す。
+#
+# 無い可能性のあるキーは `dig` で既定値付きに読むこと（理由は
+# `.claude/rules/chezmoi.md`）。`.chezmoi.requireGUI` は設定していないマシンが、
+# `.chezmoi.kernel` / `.chezmoi.osRelease` は `/proc/sys/kernel` や
+# `/etc/os-release` が読めない環境が、それぞれ空になる。
+REQUIRE_GUI={{ if and (not (dig "osrelease" "" .chezmoi.kernel | lower | contains "microsoft")) (dig "requireGUI" true .chezmoi) }}true{{ else }}false{{ end }}
 export REQUIRE_GUI
 exec bash "{{ .chezmoi.sourceDir }}/scripts/setup-ubuntu.sh"
 {{ end }}

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -5,6 +5,8 @@
 #
 # REQUIRE_GUI: ランチャーが注入する。「非WSL **かつ** GUI が必要」の意味で、
 # 単に「GUIが必要」ではない。WSL では常に false になる。
+# ランチャーを経由せず直接実行された場合は判断材料が無いので、安全側
+# （フォントを入れない）に倒す。ランチャー経由の既定は非WSLなら true。
 REQUIRE_GUI="${REQUIRE_GUI:-false}"
 
 sudo apt update


### PR DESCRIPTION
Closes #216

## やったこと

`.chezmoi.requireGUI` を `dig "requireGUI" true .chezmoi` で読むようにして、このキーを
設定していないマシンでも `chezmoi apply` が通るようにした。あわせて、同じ失敗を二度と
持ち込まないための静的検査（規約4）と E2E の回帰テストを追加した。

## 方針の判断（issue の候補1と2）

**候補2（既定値付きで読む）を採用**した。候補1（`.chezmoi.toml.tmpl` で値を確定させる）も
一度実装して隔離環境で測ったが、割に合わなかったので破棄している。

| 候補1で起きたこと | 実測 |
| --- | --- |
| `chezmoi init` が TTY 必須になる | `promptBoolOnce` は stdin ではなく `/dev/tty` を直接開くので、パイプでも答えられない。非対話プロビジョニングから `chezmoi init --apply` を叩く経路が確実に壊れる |
| 再 init が config を丸ごと再生成する | `requireGUI` は保持されるが、同じファイルの `encryption` や `[git]` は黙って消えた |
| 恒久的な結合 | テンプレートを変えるたび既存マシンに「config file template has changed」の警告が出続ける |

**直そうとした失敗（非WSL かつ未設定のマシンで apply が落ちる）より、持ち込む失敗のほうが
広い**ため取らなかった。

候補2の懸念だった「失敗を『フォントが入らない』に黙って変える」は、既定値を
**「非WSLならGUI機とみなす」** に置くことで起きない。倒れる先は「ヘッドレス機に日本語
フォントが3つ入る」で、`requireGUI = false` で止められる。

真理値表で変わるのは1セルだけ（親コミットとの `chezmoi archive` 差分で確認済み）:

| WSL | requireGUI | 変更前 | 変更後 |
| --- | --- | --- | --- |
| no | 未設定 | **エラー** | **true** |
| no | true | true | true |
| no | false | false | false |
| yes | any | false | false |

## 変更点

- **ランチャー**: `dig` で既定値付きに読む。同じ式の `.chezmoi.kernel.osrelease` と
  `.chezmoi.osRelease.id` も直接参照のままで、`/proc/sys/kernel` や `/etc/os-release` が
  読めない環境では #216 と同種の失敗をする（mount namespace で再現した）ため、あわせて `dig` にした
- **規約4を静的検査に追加**（`check-repo-conventions.sh`）: config を持たない状態で
  `chezmoi archive` し、レンダリングが通るかを chezmoi 自身に判定させる。文字列で
  「非組み込みキーの直接参照」を探すとホワイトリスト維持とコメントの誤検知がついて回るため。
  `include` 先の欠落やテンプレート構文エラーも同時に捕まる（0.2秒、実ホームへの書き込みなし）
- **E2E**: これまで CI は `requireGUI` を自分で書いてから apply していて、実環境を再現して
  いなかった。config を書く処理を削り、未定義のまま apply する（#216 の回帰テスト）。
  続けて `requireGUI = false` を書いて apply し、明示値が既定に勝つことと config がある
  状態の apply 経路も通す
- **ドキュメント**: README（利用者向けの手順）、CLAUDE.md（方針・静的検査の表・検査されない
  範囲）、`.claude/rules/chezmoi.md`（テンプレート実装の規則）

## 検証

chezmoi 2.72.0 を隔離環境で動かして実測した:

- 親コミット + config なし → `map has no entry for key "requireGUI"` で失敗（#216 の再現）
- 本 PR + config なし → 成功、`REQUIRE_GUI=true`
- `/proc/sys` と `/etc/os-release` を潰した namespace → 親は失敗、本 PR は成功
- 規約4: `dig` を直接参照に戻すと exit 1、`include` 先を消しても exit 1。実ホームへの
  書き込み・一時ファイルの残留なし（失敗時も含む）
- E2E の新ステップをワークフローから逐語で取り出して実行 → pass
- shfmt / shellcheck 0.11.0 / actionlint / markdownlint-cli2 0.23.2 / check-repo-conventions.sh
  すべて green

## 残した判断と、今回触っていないこと

- **`[data.chezmoi]` は動かさない**。テンプレートは chezmoi 自身の config しかデータ源に
  できないので `~/.config/local/` は使えない。`[data.chezmoi]` は chezmoi の予約名前空間に
  相乗りしていて組み込みキー（`os` 等）を警告なく上書きできる形なので本来は `[data]` 直下が
  素直だが、移設すると既存マシンの設定が黙って無視されて既定に戻る。注意点を CLAUDE.md に
  書いて現状維持にした
- 規約4の穴（実行OSでレンダリングされないテンプレートと未通過の分岐は見ない、組み込みキーの
  直接参照は検出できない、CIのchezmoiは版非固定）は CLAUDE.md の「検査されない範囲」に明記した
- レビュー中に見つけた別件: `.chezmoiignore` の一部の行がソースファイル名で書かれているが、
  chezmoi はターゲット名でマッチするため効いていない（例: `executable_once_setup_ubuntu.sh.tmpl`）。
  本 PR の範囲外なので触っていない

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfqW5pMaD3m2HgNpJhgfLN)_